### PR TITLE
fix: add config validation after custom config first-run generation (#93)

### DIFF
--- a/blocky/rootfs/etc/cont-init.d/config.sh
+++ b/blocky/rootfs/etc/cont-init.d/config.sh
@@ -35,6 +35,14 @@ if bashio::config.true 'custom_config'; then
             exit 1
         fi
 
+        # Validate the generated configuration
+        bashio::log.info "Validating generated configuration..."
+        if blocky validate --config "${ADDON_CONFIG_PATH}/config.yml" 2>&1; then
+            bashio::log.info "Configuration validation passed"
+        else
+            bashio::log.warning "Configuration validation reported issues - review your config"
+        fi
+
         bashio::log.info "Initial config created. You can now customize /addon_config/<repository>_blocky/config.yml"
     fi
 else


### PR DESCRIPTION
## Summary
- Adds a `blocky validate` step after tempio generates the initial configuration in custom config first-run mode
- Uses warning-level logging so validation issues inform the user without preventing first-run completion
- Catches invalid YAML early before users start customizing a broken starting config

## Test plan
- [ ] Enable custom config mode on a fresh install (no existing config.yml)
- [ ] Verify tempio generates config and `blocky validate` runs against it
- [ ] Confirm validation pass logs "Configuration validation passed"
- [ ] Test with intentionally broken template output to verify warning is logged
- [ ] Verify existing config.yml path (custom config already exists) is unaffected

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)