### PR TITLE
fix: make Renovate custom manager regex more robust (#81)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
       "customType": "regex",
       "fileMatch": ["(^|/)Dockerfile$"],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+)\\nARG\\s+[A-Z_]+_VERSION=(?<currentValue>.+)"
+        "#\\s*renovate:\\s*datasource=(?<datasource>[a-zA-Z-]+)\\s+depName=(?<depName>[^\\s]+)\\s*\\n+ARG\\s+[A-Z_]+_VERSION=(?<currentValue>.+)"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- Widen datasource capture group from `[a-z-]+` to `[a-zA-Z-]+` to support potential uppercase datasource names
- Replace `\n` with `\s*\n+` to allow trailing whitespace and blank lines between the renovate comment and the ARG line

## Problem
The existing regex in the Renovate custom manager had two fragility issues:
1. `\n` required immediate adjacency between the `# renovate:` comment and the `ARG` line — no blank lines or extra whitespace was tolerated
2. `[a-z-]` for the datasource capture group excluded uppercase characters, which while not currently needed, made the pattern unnecessarily restrictive

## Fix
Made the regex more tolerant by:
1. Adding `\s*\n+` to allow optional trailing whitespace and one or more newlines between the comment and ARG directive
2. Widening the datasource pattern to `[a-zA-Z-]+` for future-proofing

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)