### PR TITLE
docs: fix inconsistent custom config path in README

### DIFF
--- a/blocky/README.md
+++ b/blocky/README.md
@@ -80,7 +80,7 @@ Configure the add-on through the Home Assistant UI. Your settings are converted 
 For advanced users who want full control:
 
 1. Enable **Custom Config** in the add-on configuration
-2. Place your `config.yml` in `/addon_config/blocky_config/`
+2. Place your `config.yml` in `/addon_config/<repository>_blocky/`
 3. Your custom configuration will be used directly
 
 **Warning:** In custom config mode, UI settings are ignored and your configuration file will not be overwritten.
@@ -126,7 +126,7 @@ You can disable these or add your own custom lists in the configuration.
 
 ### Password Storage
 
-**Important:** Home Assistant encrypts passwords in the add-on configuration (using the `password` field type), but they must be written in plaintext to the generated Blocky configuration files (`/config/config.yml` and `/addon_config/blocky_config/config.yml`) for Blocky to read them.
+**Important:** Home Assistant encrypts passwords in the add-on configuration (using the `password` field type), but they must be written in plaintext to the generated Blocky configuration file (`/addon_config/<repository>_blocky/config.yml`) for Blocky to read them.
 
 **What This Means:**
 - Passwords are encrypted in Home Assistant's add-on configuration storage ✓


### PR DESCRIPTION
## Summary
- Fix `blocky/README.md` line 83: `/addon_config/blocky_config/` → `/addon_config/<repository>_blocky/`
- Fix `blocky/README.md` line 129: Remove confusing dual-path reference (`/config/config.yml and /addon_config/blocky_config/config.yml`) and use the single correct host path `/addon_config/<repository>_blocky/config.yml`

This aligns the README with the paths already used in `DOCS.md`, `translations/en.yaml`, and the init script (`config.sh`).

Fixes #68

## Test plan
- [x] Verify all custom config path references in `blocky/README.md` now use `/addon_config/<repository>_blocky/`
- [x] Confirm consistency with `DOCS.md` (line 149), `translations/en.yaml` (line 389), and `config.sh` log messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)