### PR TITLE
fix: URL-encode PostgreSQL credentials with special characters

### DIFF
--- a/blocky/rootfs/usr/share/tempio/blocky.gtpl
+++ b/blocky/rootfs/usr/share/tempio/blocky.gtpl
@@ -264,7 +264,7 @@ queryLog:
 {{- if eq $queryLog.type "mysql" }}
   target: {{ if $queryLog.db_username }}{{ $queryLog.db_username }}{{ if $queryLog.db_password }}:{{ $queryLog.db_password }}{{ end }}@{{ end }}tcp({{ $queryLog.db_host }}:{{ $port }})/{{ $queryLog.db_database }}?charset=utf8mb4&parseTime=True
 {{- else }}
-  target: postgres://{{ if $queryLog.db_username }}{{ $queryLog.db_username }}{{ if $queryLog.db_password }}:{{ $queryLog.db_password }}{{ end }}@{{ end }}{{ $queryLog.db_host }}:{{ $port }}/{{ $queryLog.db_database }}
+  target: postgres://{{ if $queryLog.db_username }}{{ urlquery $queryLog.db_username | replace "+" "%20" }}{{ if $queryLog.db_password }}:{{ urlquery $queryLog.db_password | replace "+" "%20" }}{{ end }}@{{ end }}{{ $queryLog.db_host }}:{{ $port }}/{{ $queryLog.db_database }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

- URL-encode username and password in PostgreSQL/Timescale connection strings using `urlquery` + `replace "+" "%20"` to handle special characters (`:`, `@`, `/`, `%`, `?`, `#`) that break URL parsing
- MySQL DSN format intentionally left unchanged — go-sql-driver handles special characters natively and encoding would break authentication

Fixes #65

## Test plan

- [ ] Configure a PostgreSQL query log target with a password containing special characters (e.g., `p@ss:word`) and verify the generated config produces a properly encoded connection string (`postgres://user:p%40ss%3Aword@host:5432/db`)
- [ ] Confirm MySQL query log target with the same special-character password remains unencoded (`user:p@ss:word@tcp(host:port)/db`)
- [ ] Verify normal passwords without special characters still work for both database types

🤖 Generated with [Claude Code](https://claude.com/claude-code)