### PR TITLE
fix: sync build.yaml base image version with Dockerfile

### DIFF
--- a/blocky/build.yaml
+++ b/blocky/build.yaml
@@ -1,10 +1,10 @@
 ---
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
 build_from:
-  amd64: ghcr.io/home-assistant/amd64-base:3.20
-  armv7: ghcr.io/home-assistant/armv7-base:3.20
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.20
-  armhf: ghcr.io/home-assistant/armhf-base:3.20
+  amd64: ghcr.io/home-assistant/amd64-base:3.23
+  armv7: ghcr.io/home-assistant/armv7-base:3.23
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.23
+  armhf: ghcr.io/home-assistant/armhf-base:3.23
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Blocky"
   org.opencontainers.image.description: "Fast and lightweight DNS proxy and ad-blocker"

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,15 @@
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+)\\nARG\\s+[A-Z_]+_VERSION=(?<currentValue>.+)"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Track Home Assistant base image versions in build.yaml",
+      "fileMatch": ["(^|/)build\\.yaml$"],
+      "matchStrings": [
+        "\\s+\\w+:\\s+(?<depName>ghcr\\.io/home-assistant/[\\w-]+-base):(?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "docker"
     }
   ],
   "timezone": "Europe/Berlin",


### PR DESCRIPTION
## Summary
- Update all four architecture base images in `build.yaml` from 3.20 to 3.23 to match the Dockerfile
- Add a Renovate regex custom manager for `build.yaml` so future base image updates are applied to both files in a single PR (grouped via the existing "Home Assistant base images" package rule)

Closes #63

## Test plan
- [ ] Verify `build.yaml` versions match `Dockerfile` `HOME_ASSISTANT_BASE_VERSION` (both 3.23)
- [ ] Confirm Renovate detects all four `build.yaml` entries as docker dependencies (check Dependency Dashboard after merge)
- [ ] Validate next base image bump PR updates both `Dockerfile` and `build.yaml` together

🤖 Generated with [Claude Code](https://claude.com/claude-code)