### PR TITLE
fix: validate Blocky config before service startup

### DIFF
--- a/blocky/rootfs/etc/services.d/blocky/run
+++ b/blocky/rootfs/etc/services.d/blocky/run
@@ -27,6 +27,13 @@ if [ ! -s "${CONFIG_FILE}" ]; then
     exit 1
 fi
 
+# Validate configuration against Blocky's schema
+bashio::log.info "Validating Blocky configuration..."
+if ! blocky validate --config "${CONFIG_FILE}"; then
+    bashio::log.fatal "Configuration validation failed: ${CONFIG_FILE}"
+    exit 1
+fi
+
 bashio::log.info "Pre-flight checks passed"
 bashio::log.info "Starting Blocky..."
 


### PR DESCRIPTION
## Summary
- Adds `blocky validate --config` step after pre-flight file checks and before starting the Blocky service
- Catches malformed configuration errors at startup instead of letting Blocky fail at runtime
- Exits with a fatal error and clear log message if validation fails

Closes #64

## Test plan
- [ ] Deploy add-on with a valid configuration and verify Blocky starts normally
- [ ] Deploy add-on with an intentionally malformed config and verify it exits with a clear validation error instead of a runtime crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)