### PR TITLE
fix: warn users when custom config mode ignores UI options

### DIFF
--- a/blocky/DOCS.md
+++ b/blocky/DOCS.md
@@ -146,7 +146,14 @@ Resolve client IP addresses to friendly names using reverse DNS and static mappi
 
 ### Custom Config Mode
 
-Enable to use manual YAML configuration at `/addon_config/<repository>_blocky/config.yml`. All UI settings are ignored when enabled. Use for advanced Blocky features not available in UI (regex patterns, per-client rules, etc.).
+> **WARNING:** When Custom Configuration Mode is enabled, **all settings configured in the Home Assistant UI are completely ignored**. Any changes made through the UI will have no effect on Blocky's behavior. A persistent notification will appear in Home Assistant as a reminder.
+
+Enable to use manual YAML configuration at `/addon_config/<repository>_blocky/config.yml`. Use for advanced Blocky features not available in the UI (regex patterns, per-client rules, EDE, special protocols, etc.).
+
+**How it works:**
+- **First start with custom config enabled:** The add-on generates an initial `config.yml` from your current UI settings as a starting point
+- **Subsequent starts:** The existing `config.yml` is used as-is; UI options are ignored
+- **Switching back:** Disable Custom Configuration Mode and restart to return to UI-based configuration
 
 ## Configuration Examples
 

--- a/blocky/README.md
+++ b/blocky/README.md
@@ -77,13 +77,16 @@ Configure the add-on through the Home Assistant UI. Your settings are converted 
 
 ### Custom Config Mode
 
-For advanced users who want full control:
+> **WARNING:** When Custom Configuration Mode is enabled, **all UI options are completely ignored**. Any changes you make in the Home Assistant add-on configuration UI will have **no effect**. You must edit the YAML file directly. A persistent notification will appear in Home Assistant to remind you that custom config mode is active.
 
-1. Enable **Custom Config** in the add-on configuration
-2. Place your `config.yml` in `/addon_config/<repository>_blocky/`
-3. Your custom configuration will be used directly
+For advanced users who want full control over Blocky's configuration:
 
-**Warning:** In custom config mode, UI settings are ignored and your configuration file will not be overwritten.
+1. Enable **Custom Configuration Mode** in the add-on configuration
+2. On first start, an initial `config.yml` is generated from your current UI settings
+3. Edit `/addon_config/<repository>_blocky/config.yml` directly for all future changes
+4. To return to UI-based configuration, disable **Custom Configuration Mode** and restart
+
+This mode is useful for accessing advanced Blocky features not exposed in the UI, such as per-client blocking rules, regex patterns, EDE (Extended DNS Errors), and special protocols.
 
 ## Basic Usage
 

--- a/blocky/translations/en.yaml
+++ b/blocky/translations/en.yaml
@@ -384,6 +384,6 @@ configuration:
           Obfuscates sensitive data in logs by replacing alphanumeric characters with asterisks (*). Affects DNS query domains and response data. Enable in shared environments or for compliance requirements (e.g., GDPR). When enabled, logs will show patterns like "query: *********" instead of actual domains. Default: false.
 
   custom_config:
-    name: Custom Configuration Mode
+    name: "Custom Configuration Mode (WARNING: disables all UI options)"
     description: >-
-      Enable custom configuration mode to manually edit Blocky's configuration file directly. When enabled, all Home Assistant UI options are ignored, and you must edit the YAML file at /addon_config/<repository>_blocky/config.yml. Use this for advanced Blocky features not available in the UI, such as per-client blocking rules, query logging, regex patterns, and custom DNS records. On first enable, the add-on generates an initial config from your current UI settings as a starting point. See documentation for full details. Default: false (use UI configuration).
+      WARNING: When enabled, ALL settings configured in the UI above are COMPLETELY IGNORED. Any changes you make in the UI will have NO effect on Blocky's behavior. You must edit the YAML configuration file directly at /addon_config/<repository>_blocky/config.yml. A persistent notification will appear in Home Assistant as a reminder. On first enable, the add-on generates an initial config from your current UI settings as a starting point. To return to UI-based configuration, disable this option and restart. Use this mode only for advanced Blocky features not available in the UI, such as per-client blocking rules, regex patterns, and EDE. Default: false (use UI configuration).


### PR DESCRIPTION
## Summary
Closes #85

- **Persistent HA notification**: When custom config mode is active, a persistent notification appears in the Home Assistant UI warning users that all UI settings are being ignored. The notification is automatically dismissed when switching back to standard mode.
- **Enhanced log warnings**: Improved warning messages in `config.sh` to clearly state that UI changes have no effect and how to switch back.
- **UI field label updated**: The `custom_config` toggle in `translations/en.yaml` now includes `(WARNING: disables all UI options)` in its name, and the description leads with an explicit warning.
- **README & DOCS updated**: Both documentation files now include prominent warning callouts explaining the implications of custom config mode, how the two modes work, and how to switch between them.

> **Note**: Home Assistant's add-on framework does not support programmatically disabling/greying out UI fields, so a persistent notification combined with prominent warnings is the best available approach.

## Test plan
- [ ] Enable custom config mode → verify persistent notification appears in HA
- [ ] Check add-on logs for clear warning messages about UI options being ignored
- [ ] Disable custom config mode and restart → verify notification is dismissed
- [ ] Verify the `custom_config` field in the HA UI shows the updated name and description
- [ ] Review README and DOCS for clear warning callouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)