### PR TITLE
fix: enable query logging privacy mode by default

### DIFF
--- a/blocky/DOCS.md
+++ b/blocky/DOCS.md
@@ -142,7 +142,7 @@ Resolve client IP addresses to friendly names using reverse DNS and static mappi
 ### Logging
 
 - **Level**: `trace`, `debug`, `info` (default), `warn`, `error`
-- **Privacy Mode**: Obfuscate domains and IPs in logs with asterisks
+- **Privacy Mode**: Obfuscate domains and IPs in logs with asterisks (enabled by default). Disable only when full domain visibility is needed for debugging. Note that even with privacy mode enabled, query metadata (timing, frequency, response types) may still reveal browsing patterns.
 
 ### Custom Config Mode
 

--- a/blocky/README.md
+++ b/blocky/README.md
@@ -156,16 +156,16 @@ You can disable these or add your own custom lists in the configuration.
 
 ### Query Logging Privacy
 
-Query logs contain all DNS requests from your network, which may include sensitive information:
-- Websites visited by household members
-- Smart device communication patterns
-- Application network activity
+> **WARNING:** Query logs contain sensitive information about all DNS activity on your network, including websites visited by household members, smart device communication patterns, and application network activity. Only enable query logging when actively needed for debugging or analysis.
+
+Privacy mode is **enabled by default** to obfuscate domain names and client IPs in logs. Even with privacy mode enabled, query metadata (timing, frequency, response types) may still reveal browsing patterns.
 
 Recommendations:
-- Only enable query logging if necessary
-- Restrict access to log files
-- Consider privacy implications before enabling database logging
-- Regularly rotate or purge old logs
+- Only enable query logging when necessary for debugging or analysis
+- Keep privacy mode enabled unless you specifically need full domain visibility
+- Restrict access to log files and database credentials
+- Use `log_retention_days` to automatically purge old logs
+- Consider privacy implications before enabling database logging, as logs stored long-term create persistent privacy risks
 
 ## Troubleshooting
 

--- a/blocky/config.yaml
+++ b/blocky/config.yaml
@@ -109,7 +109,7 @@ options:
   log:
     level: info
     timestamp: true
-    privacy: false
+    privacy: true
   custom_config: false
 schema:
   upstreams:

--- a/blocky/translations/en.yaml
+++ b/blocky/translations/en.yaml
@@ -381,7 +381,7 @@ configuration:
       privacy:
         name: Privacy Mode
         description: >-
-          Obfuscates sensitive data in logs by replacing alphanumeric characters with asterisks (*). Affects DNS query domains and response data. Enable in shared environments or for compliance requirements (e.g., GDPR). When enabled, logs will show patterns like "query: *********" instead of actual domains. Default: false.
+          Obfuscates sensitive data in logs by replacing alphanumeric characters with asterisks (*). Affects DNS query domains and response data. WARNING: When disabled, full domain names and client IP addresses are logged in plaintext, exposing browsing habits of all network users. Even with privacy mode enabled, query metadata (timing, frequency, response types) may still reveal browsing patterns. Enable in shared environments or for compliance requirements (e.g., GDPR). When enabled, logs will show patterns like "query: *********" instead of actual domains. Default: true (enabled).
 
   custom_config:
     name: Custom Configuration Mode


### PR DESCRIPTION
## Summary
- Change default `log.privacy` from `false` to `true` so domain names and client IPs are obfuscated in logs by default
- Add explicit privacy warning to the UI schema description in `translations/en.yaml`
- Update README and DOCS to document that privacy mode is now enabled by default and that query metadata may still reveal browsing patterns even with privacy enabled
- Strengthen query logging recommendations (use `log_retention_days`, keep privacy enabled, restrict credentials)

## Test plan
- [ ] Verify new installations default to `privacy: true` in generated Blocky config
- [ ] Verify existing installations with explicit `privacy: false` retain their setting
- [ ] Confirm privacy mode description is visible in Home Assistant add-on UI
- [ ] Test that Blocky starts correctly with `privacy: true`

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)