### PR TITLE
fix: restrict config file permissions and scrub secrets from logs

### DIFF
--- a/blocky/rootfs/etc/cont-init.d/config.sh
+++ b/blocky/rootfs/etc/cont-init.d/config.sh
@@ -12,6 +12,14 @@ bashio::log.info "Configuring Blocky..."
 mkdir -p "${CONFIG_PATH}"
 mkdir -p "${ADDON_CONFIG_PATH}"
 
+# ------------------------------------------------------------------------------
+# Restrict config directory permissions
+# Config files may contain plaintext passwords for Redis, MySQL, and PostgreSQL.
+# Ensure only root can read/write the directories and their contents.
+# ------------------------------------------------------------------------------
+chmod 700 "${CONFIG_PATH}"
+chmod 700 "${ADDON_CONFIG_PATH}"
+
 # Check if custom configuration is enabled
 if bashio::config.true 'custom_config'; then
     if [ -f "${ADDON_CONFIG_PATH}/config.yml" ]; then
@@ -54,11 +62,17 @@ else
     fi
 fi
 
+# Restrict config file permissions (contains plaintext passwords)
+chmod 600 "${ADDON_CONFIG_PATH}/config.yml"
+
 # Copy the generated config to the runtime location
 if ! cp "${ADDON_CONFIG_PATH}/config.yml" "${CONFIG_PATH}/config.yml"; then
     bashio::log.fatal "Failed to copy configuration to runtime location"
     exit 1
 fi
+
+# Restrict runtime config file permissions (contains plaintext passwords)
+chmod 600 "${CONFIG_PATH}/config.yml"
 
 # Create query log directory if CSV logging is enabled
 if bashio::config.has_value 'query_log.target'; then

--- a/blocky/rootfs/etc/services.d/blocky/run
+++ b/blocky/rootfs/etc/services.d/blocky/run
@@ -3,6 +3,9 @@
 # Start Blocky service
 # ==============================================================================
 
+# shellcheck source=/dev/null
+source /usr/local/lib/blocky-helpers.sh
+
 declare -a options
 readonly CONFIG_FILE="/etc/blocky/config.yml"
 
@@ -28,11 +31,14 @@ if [ ! -s "${CONFIG_FILE}" ]; then
 fi
 
 # Validate configuration against Blocky's schema
+# Scrub secrets from validation output to prevent password leakage in logs
 bashio::log.info "Validating Blocky configuration..."
-if ! blocky validate --config "${CONFIG_FILE}"; then
+validate_output="$(blocky validate --config "${CONFIG_FILE}" 2>&1)" || {
+    echo "${validate_output}" | scrub_secrets
     bashio::log.fatal "Configuration validation failed: ${CONFIG_FILE}"
     exit 1
-fi
+}
+echo "${validate_output}" | scrub_secrets
 
 bashio::log.info "Pre-flight checks passed"
 bashio::log.info "Starting Blocky..."

--- a/blocky/rootfs/usr/local/lib/blocky-helpers.sh
+++ b/blocky/rootfs/usr/local/lib/blocky-helpers.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Shared helper functions for Blocky add-on scripts
+# ==============================================================================
+
+# Build a sed expression that replaces known secret values with "********".
+# Reads redis.password and query_log.db_password from the add-on options.
+# Usage: some_command 2>&1 | scrub_secrets
+scrub_secrets() {
+    local -a sed_args=()
+
+    local redis_pw
+    if bashio::config.has_value 'redis.password'; then
+        redis_pw="$(bashio::config 'redis.password')"
+        if [[ -n "${redis_pw}" ]]; then
+            sed_args+=(-e "s/${redis_pw}/********/g")
+        fi
+    fi
+
+    local db_pw
+    if bashio::config.has_value 'query_log.db_password'; then
+        db_pw="$(bashio::config 'query_log.db_password')"
+        if [[ -n "${db_pw}" ]]; then
+            sed_args+=(-e "s/${db_pw}/********/g")
+        fi
+    fi
+
+    if [[ ${#sed_args[@]} -gt 0 ]]; then
+        sed "${sed_args[@]}"
+    else
+        cat
+    fi
+}


### PR DESCRIPTION
## Summary
- Set `chmod 700` on config directories (`/etc/blocky`, `/config`) so only root can list contents
- Set `chmod 600` on both config files (`/config/config.yml` and `/etc/blocky/config.yml`) after generation/copy to prevent unauthorized reads of plaintext passwords
- Add shared `scrub_secrets` helper that replaces Redis and database passwords with `********` in log output
- Scrub Blocky validation output to prevent password leakage in Home Assistant logs

## Test plan
- [ ] Start add-on with Redis password configured and verify `/etc/blocky/config.yml` has `600` permissions (`ls -la`)
- [ ] Start add-on with database query logging configured and verify both config files have `600` permissions
- [ ] Trigger a validation error and verify passwords are redacted from log output
- [ ] Verify normal startup still works correctly with restricted permissions
- [ ] Verify custom config mode still works with restricted permissions

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)