### PR TITLE
fix: quote user-supplied values in Tempio template to prevent YAML injection

### DIFF
--- a/blocky/rootfs/usr/share/tempio/blocky.gtpl
+++ b/blocky/rootfs/usr/share/tempio/blocky.gtpl
@@ -9,23 +9,23 @@
 upstreams:
   groups:
 {{- range .upstreams.groups }}
-    {{ .name }}:
+    {{ .name | quote }}:
 {{- range .resolvers }}
-      - {{ . }}
+      - {{ . | quote }}
 {{- end }}
 {{- end }}
 {{- if .upstreams.init_strategy }}
   init:
-    strategy: {{ .upstreams.init_strategy }}
+    strategy: {{ .upstreams.init_strategy | quote }}
 {{- end }}
 {{- if .upstreams.strategy }}
-  strategy: {{ .upstreams.strategy }}
+  strategy: {{ .upstreams.strategy | quote }}
 {{- end }}
 {{- if .upstreams.timeout }}
-  timeout: {{ .upstreams.timeout }}
+  timeout: {{ .upstreams.timeout | quote }}
 {{- end }}
 {{- if .upstreams.user_agent }}
-  userAgent: {{ .upstreams.user_agent }}
+  userAgent: {{ .upstreams.user_agent | quote }}
 {{- end }}
 
 
@@ -33,11 +33,11 @@ upstreams:
 # Bootstrap DNS
 bootstrapDns:
 {{- range .bootstrap.dns }}
-  - upstream: {{ .upstream }}
+  - upstream: {{ .upstream | quote }}
 {{- if .ips }}
     ips:
 {{- range .ips }}
-      - {{ . }}
+      - {{ . | quote }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -48,7 +48,7 @@ bootstrapDns:
 filtering:
   queryTypes:
 {{- range .filtering.query_types }}
-    - {{ . }}
+    - {{ . | quote }}
 {{- end }}
 {{- end }}
 
@@ -61,18 +61,18 @@ fqdnOnly:
 {{- if or .custom_dns.mapping .custom_dns.rewrite }}
 # Custom DNS
 customDNS:
-  customTTL: {{ .custom_dns.custom_ttl }}
+  customTTL: {{ .custom_dns.custom_ttl | quote }}
   filterUnmappedTypes: {{ .custom_dns.filter_unmapped_types }}
 {{- if .custom_dns.rewrite }}
   rewrite:
 {{- range .custom_dns.rewrite }}
-    {{ .source }}: {{ .target }}
+    {{ .source | quote }}: {{ .target | quote }}
 {{- end }}
 {{- end }}
 {{- if .custom_dns.mapping }}
   mapping:
 {{- range .custom_dns.mapping }}
-    {{ .hostname }}: {{ .ips }}
+    {{ .hostname | quote }}: {{ .ips | quote }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -83,13 +83,13 @@ conditional:
 {{- if .conditional.rewrite }}
   rewrite:
 {{- range .conditional.rewrite }}
-    {{ .source }}: {{ .target }}
+    {{ .source | quote }}: {{ .target | quote }}
 {{- end }}
 {{- end }}
 {{- if .conditional.mapping }}
   mapping:
 {{- range .conditional.mapping }}
-    {{ .domain }}: {{ range $index, $resolver := .resolvers }}{{if $index}},{{end}}{{ $resolver }}{{end}}
+    {{ .domain | quote }}: "{{ range $index, $resolver := .resolvers }}{{if $index}},{{end}}{{ $resolver | replace `\` `\\` | replace `"` `\"` }}{{end}}"
 {{- end }}
 {{- end }}
 {{- if .conditional.fallback_upstream }}
@@ -106,7 +106,7 @@ conditional:
 # Client Name Lookup
 clientLookup:
 {{- if $upstream }}
-  upstream: {{ $upstream }}
+  upstream: {{ $upstream | quote }}
 {{- end }}
 {{- if $singleOrder }}
   singleNameOrder:
@@ -118,9 +118,9 @@ clientLookup:
   clients:
 {{- range $entry := $clients }}
 {{- if and $entry.name $entry.addresses }}
-    {{ $entry.name }}:
+    {{ $entry.name | quote }}:
 {{- range $address := $entry.addresses }}
-      - {{ $address }}
+      - {{ $address | quote }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -141,9 +141,9 @@ blocking:
   denylists:
 {{- range $list := $denylists }}
 {{- if and $list.name $list.sources }}
-    {{ $list.name }}:
+    {{ $list.name | quote }}:
 {{- range $source := $list.sources }}
-      - {{ $source }}
+      - {{ $source | quote }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -152,9 +152,9 @@ blocking:
   allowlists:
 {{- range $list := $allowlists }}
 {{- if and $list.name $list.sources }}
-    {{ $list.name }}:
+    {{ $list.name | quote }}:
 {{- range $source := $list.sources }}
-      - {{ $source }}
+      - {{ $source | quote }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -163,18 +163,18 @@ blocking:
   clientGroupsBlock:
 {{- range $group := $clientGroups }}
 {{- if and $group.name $group.lists }}
-    {{ $group.name }}:
+    {{ $group.name | quote }}:
 {{- range $listName := $group.lists }}
-      - {{ $listName }}
+      - {{ $listName | quote }}
 {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
 {{- if $blocking.block_type }}
-  blockType: {{ $blocking.block_type }}
+  blockType: {{ $blocking.block_type | quote }}
 {{- end }}
 {{- if $blocking.block_ttl }}
-  blockTTL: {{ $blocking.block_ttl }}
+  blockTTL: {{ $blocking.block_ttl | quote }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -185,10 +185,10 @@ blocking:
 # DNS Caching
 caching:
 {{- if $caching.min_time }}
-  minTime: {{ $caching.min_time }}
+  minTime: {{ $caching.min_time | quote }}
 {{- end }}
 {{- if $caching.max_time }}
-  maxTime: {{ $caching.max_time }}
+  maxTime: {{ $caching.max_time | quote }}
 {{- end }}
 {{- if $caching.max_items_count }}
   maxItemsCount: {{ $caching.max_items_count }}
@@ -197,7 +197,7 @@ caching:
   prefetching: {{ $caching.prefetching }}
 {{- end }}
 {{- if $caching.prefetch_expires }}
-  prefetchExpires: {{ $caching.prefetch_expires }}
+  prefetchExpires: {{ $caching.prefetch_expires | quote }}
 {{- end }}
 {{- if $caching.prefetch_threshold }}
   prefetchThreshold: {{ $caching.prefetch_threshold }}
@@ -206,12 +206,12 @@ caching:
   prefetchMaxItemsCount: {{ $caching.prefetch_max_items_count }}
 {{- end }}
 {{- if $caching.cache_time_negative }}
-  cacheTimeNegative: {{ $caching.cache_time_negative }}
+  cacheTimeNegative: {{ $caching.cache_time_negative | quote }}
 {{- end }}
 {{- if $caching.exclude }}
   exclude:
 {{- range $caching.exclude }}
-    - {{ . }}
+    - {{ . | quote }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -220,24 +220,24 @@ caching:
 {{- if $redis.address }}
 # Redis Integration
 redis:
-  address: {{ $redis.address }}
+  address: {{ $redis.address | quote }}
 {{- if $redis.username }}
-  username: {{ $redis.username }}
+  username: {{ $redis.username | quote }}
 {{- end }}
 {{- if $redis.password }}
-  password: {{ $redis.password }}
+  password: {{ $redis.password | quote }}
 {{- end }}
   database: {{ $redis.database }}
   required: {{ $redis.required }}
   connectionAttempts: {{ $redis.connection_attempts }}
-  connectionCooldown: {{ $redis.connection_cooldown }}
+  connectionCooldown: {{ $redis.connection_cooldown | quote }}
 {{- end }}
 
 {{- if .prometheus.enable }}
 # Prometheus Metrics
 prometheus:
   enable: {{ .prometheus.enable }}
-  path: {{ .prometheus.path }}
+  path: {{ .prometheus.path | quote }}
 {{- end }}
 
 
@@ -245,10 +245,10 @@ prometheus:
 {{- if $queryLog.type }}
 # Query Logging
 queryLog:
-  type: {{ $queryLog.type }}
+  type: {{ $queryLog.type | quote }}
 {{- if or (eq $queryLog.type "csv") (eq $queryLog.type "csv-client") }}
 {{- if $queryLog.target }}
-  target: {{ $queryLog.target }}
+  target: {{ $queryLog.target | quote }}
 {{- end }}
 {{- end }}
 {{- if or (eq $queryLog.type "mysql") (eq $queryLog.type "postgresql") (eq $queryLog.type "timescale") }}
@@ -262,9 +262,9 @@ queryLog:
 {{- end }}
 {{- end }}
 {{- if eq $queryLog.type "mysql" }}
-  target: {{ if $queryLog.db_username }}{{ $queryLog.db_username }}{{ if $queryLog.db_password }}:{{ $queryLog.db_password }}{{ end }}@{{ end }}tcp({{ $queryLog.db_host }}:{{ $port }})/{{ $queryLog.db_database }}?charset=utf8mb4&parseTime=True
+  target: "{{ if $queryLog.db_username }}{{ $queryLog.db_username | replace `\` `\\` | replace `"` `\"` }}{{ if $queryLog.db_password }}:{{ $queryLog.db_password | replace `\` `\\` | replace `"` `\"` }}{{ end }}@{{ end }}tcp({{ $queryLog.db_host | replace `\` `\\` | replace `"` `\"` }}:{{ $port }})/{{ $queryLog.db_database | replace `\` `\\` | replace `"` `\"` }}?charset=utf8mb4&parseTime=True"
 {{- else }}
-  target: postgres://{{ if $queryLog.db_username }}{{ urlquery $queryLog.db_username | replace "+" "%20" }}{{ if $queryLog.db_password }}:{{ urlquery $queryLog.db_password | replace "+" "%20" }}{{ end }}@{{ end }}{{ $queryLog.db_host }}:{{ $port }}/{{ $queryLog.db_database }}
+  target: "postgres://{{ if $queryLog.db_username }}{{ urlquery $queryLog.db_username | replace "+" "%20" }}{{ if $queryLog.db_password }}:{{ urlquery $queryLog.db_password | replace "+" "%20" }}{{ end }}@{{ end }}{{ $queryLog.db_host | replace `\` `\\` | replace `"` `\"` }}:{{ $port }}/{{ $queryLog.db_database | replace `\` `\\` | replace `"` `\"` }}"
 {{- end }}
 {{- end }}
 {{- end }}
@@ -275,16 +275,16 @@ queryLog:
   creationAttempts: {{ $queryLog.creation_attempts }}
 {{- end }}
 {{- if $queryLog.creation_cooldown }}
-  creationCooldown: {{ $queryLog.creation_cooldown }}
+  creationCooldown: {{ $queryLog.creation_cooldown | quote }}
 {{- end }}
 {{- if $queryLog.fields }}
   fields:
 {{- range $queryLog.fields }}
-    - {{ . }}
+    - {{ . | quote }}
 {{- end }}
 {{- end }}
 {{- if $queryLog.flush_interval }}
-  flushInterval: {{ $queryLog.flush_interval }}
+  flushInterval: {{ $queryLog.flush_interval | quote }}
 {{- end }}
 {{- end }}
 
@@ -295,6 +295,6 @@ ports:
 
 # Logging
 log:
-  level: {{ .log.level }}
+  level: {{ .log.level | quote }}
   timestamp: {{ .log.timestamp }}
   privacy: {{ .log.privacy }}


### PR DESCRIPTION
## Summary

- Add Sprig `| quote` pipe to all user-supplied string keys (9) and values (32) in `blocky.gtpl`
- Wrap MySQL/PostgreSQL DSN connection strings in literal double quotes with `replace` escaping for `\` and `"`
- Leave booleans and integers unquoted (16 locations) — no injection risk for these types

Values containing YAML special characters (`:`, `#`, newlines) could break YAML structure or inject arbitrary Blocky configuration via the Home Assistant add-on UI.

Closes #69

## Test plan

- [ ] Build the add-on: `docker build --build-arg BUILD_ARCH=amd64 -t blocky-addon blocky`
- [ ] Render template with default options and verify output YAML is valid (only difference: double quotes around string values)
- [ ] Test edge cases: values containing `:`, `#`, `"`, `\` in string fields — verify YAML still parses correctly
- [ ] Verify custom config mode is unaffected (template rendering is bypassed)
- [ ] CI lint passes (hadolint + shellcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)