### PR TITLE
Expose startVerifyUpstream option

### DIFF
--- a/blocky/config.yaml
+++ b/blocky/config.yaml
@@ -33,6 +33,7 @@ options:
     init_strategy: blocking
     strategy: parallel_best
     timeout: 2s
+    start_verify: false
   bootstrap:
     dns:
       - upstream: 1.1.1.1
@@ -120,6 +121,7 @@ schema:
     init_strategy: list(blocking|failOnError|fast)?
     strategy: list(parallel_best|random|strict)?
     timeout: str?
+    start_verify: bool?
     user_agent: str?
   bootstrap:
     dns:

--- a/blocky/rootfs/usr/share/tempio/blocky.gtpl
+++ b/blocky/rootfs/usr/share/tempio/blocky.gtpl
@@ -24,6 +24,9 @@ upstreams:
 {{- if .upstreams.timeout }}
   timeout: {{ .upstreams.timeout | quote }}
 {{- end }}
+{{- if .upstreams.start_verify }}
+  startVerifyUpstream: true
+{{- end }}
 {{- if .upstreams.user_agent }}
   userAgent: {{ .upstreams.user_agent | quote }}
 {{- end }}

--- a/blocky/translations/en.yaml
+++ b/blocky/translations/en.yaml
@@ -21,6 +21,12 @@ configuration:
         name: Timeout
         description: >-
           Maximum time to wait for a response from upstream DNS servers before considering them unreachable. Controls how long Blocky waits before marking an upstream resolver as failed and trying the next one. Format: duration string like 2s (2 seconds), 5s (5 seconds), or 500ms (500 milliseconds). Default: 2s if not specified. Increase for slow or distant resolvers (satellite internet, VPN), decrease for faster failure detection in local networks.
+      start_verify:
+        name: Verify Upstreams on Start
+        description: >-
+          When enabled, Blocky verifies that configured upstream DNS servers are
+          reachable during startup. If no upstream is reachable, Blocky will fail
+          to start instead of running with broken DNS resolution.
       user_agent:
         name: User Agent
         description: >-


### PR DESCRIPTION
## Summary
- Add `start_verify` boolean option under `upstreams` configuration
- Maps to Blocky's native `startVerifyUpstream` setting
- Default: `false` (matches Blocky's default)
- When enabled, Blocky verifies upstream DNS servers at startup and fails fast if none are reachable

## Changes
- `blocky/config.yaml` — new option + schema entry
- `blocky/rootfs/usr/share/tempio/blocky.gtpl` — template conditional
- `blocky/translations/en.yaml` — UI description

## Test plan
- [ ] Verify all modified YAML files are valid
- [ ] Install add-on, enable "Verify Upstreams on Start", confirm Blocky config includes `startVerifyUpstream: true`
- [ ] With valid upstreams: Blocky starts normally
- [ ] With invalid upstreams: Blocky fails to start (expected behavior)
- [ ] With option disabled (default): Blocky starts without verification

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)