### PR TITLE
fix: remove paths filter from lint PR trigger

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,12 +11,6 @@ on:
       - ".github/workflows/lint.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "blocky/Dockerfile"
-      - "blocky/rootfs/**"
-      - ".hadolint.yaml"
-      - ".shellcheckrc"
-      - ".github/workflows/lint.yml"
 
 jobs:
   hadolint:


### PR DESCRIPTION
## Summary

- PRs that only change files outside the lint `paths` filter (e.g., `config.yaml` in #148) never trigger the lint workflow, so no status is reported to GitHub and branch protection blocks the PR indefinitely
- Remove the `paths` filter from the `pull_request` trigger so lint always runs on PRs to `main`
- Keep the `paths` filter on the `push` trigger (only affects post-merge runs, doesn't interact with branch protection)

## Test plan

- [ ] Verify lint checks (`Hadolint`, `ShellCheck`) appear and pass on this PR
- [ ] Confirm PRs like #148 would no longer be blocked after merging this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)