### PR TITLE
fix: validate generated config before persisting

### DIFF
--- a/blocky/rootfs/etc/cont-init.d/config.sh
+++ b/blocky/rootfs/etc/cont-init.d/config.sh
@@ -35,6 +35,12 @@ if bashio::config.true 'custom_config'; then
             exit 1
         fi
 
+        if ! blocky validate --config "${ADDON_CONFIG_PATH}/config.yml"; then
+            bashio::log.fatal "Generated initial configuration is invalid"
+            rm -f "${ADDON_CONFIG_PATH}/config.yml"
+            exit 1
+        fi
+
         bashio::log.info "Initial config created. You can now customize /addon_config/<repository>_blocky/config.yml"
     fi
 else
@@ -50,6 +56,11 @@ else
 
     if [ ! -f "${ADDON_CONFIG_PATH}/config.yml" ] || [ ! -s "${ADDON_CONFIG_PATH}/config.yml" ]; then
         bashio::log.fatal "Configuration file was not created or is empty"
+        exit 1
+    fi
+
+    if ! blocky validate --config "${ADDON_CONFIG_PATH}/config.yml"; then
+        bashio::log.fatal "Generated configuration is invalid"
         exit 1
     fi
 fi


### PR DESCRIPTION
## Summary
- Adds `blocky validate --config` after tempio generation in **both** config paths in `config.sh`
- **Custom config first-run**: on validation failure, removes the invalid file (so the next restart retries generation rather than treating it as user-customized) and exits fatally
- **Standard mode**: on validation failure, exits fatally (no file removal needed since it regenerates on every restart)

Closes #93

## Test plan
- [ ] Enable `custom_config` with no existing config file — verify initial config is validated and the "Initial config created" log appears
- [ ] Intentionally break the template to produce invalid YAML — verify the file is removed and the add-on exits with a fatal log
- [ ] Run in standard mode — verify config is validated after generation
- [ ] Confirm `shellcheck` and `hadolint` pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)