### PR TITLE
fix: allow db_port 0 as default-port sentinel in schema

### DIFF
--- a/blocky/config.yaml
+++ b/blocky/config.yaml
@@ -200,7 +200,7 @@ schema:
     type: list(|csv|csv-client|console|mysql|postgresql|timescale)?
     target: str?
     db_host: str?
-    db_port: int(1,65535)?
+    db_port: int(0,65535)?
     db_username: str?
     db_password: password?
     db_database: str?


### PR DESCRIPTION
## Summary

- Widens `db_port` schema constraint from `int(1,65535)?` to `int(0,65535)?` to allow `0` as a valid value
- Fixes a regression from #148 (`6da8b94`) where the min constraint rejects the default `db_port: 0`
- The template (`blocky.gtpl:260-266`) uses `0` as a sentinel to auto-select the default database port (3306 for MySQL, 5432 for PostgreSQL)

## Test plan

- [ ] Install updated addon in HA with existing options containing `db_port: 0` — should no longer error on schema validation
- [ ] Verify template still renders correctly: `db_port: 0` triggers auto-port logic
- [ ] `hadolint` and `shellcheck` unaffected (no shell/Dockerfile changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)