### PR TITLE
fix: use empty string defaults for caching min_time/max_time

### DIFF
--- a/blocky/config.yaml
+++ b/blocky/config.yaml
@@ -74,8 +74,8 @@ options:
     block_type: zeroIp
     block_ttl: 6h
   caching:
-    min_time: 0m
-    max_time: 0m
+    min_time: ""
+    max_time: ""
     max_items_count: 0
     prefetching: false
     prefetch_expires: 2h


### PR DESCRIPTION
## Summary

- Change `caching.min_time` and `caching.max_time` defaults from `"0m"` to `""` in `blocky/config.yaml`
- Fixes Go template truthiness edge case where non-empty `"0m"` strings always evaluated to true, causing unnecessary `minTime`/`maxTime` lines in generated Blocky config
- No template or schema changes needed — existing `{{ if $caching.min_time }}` conditionals already handle empty strings correctly

Closes #76

## Test plan

- [ ] Install add-on with default config → verify `caching:` section does not contain `minTime`/`maxTime` lines
- [ ] Set `min_time` to a non-zero value (e.g. `5m`) → verify `minTime: "5m"` appears in generated config
- [ ] Verify DNS resolution works correctly with default caching settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)