### PR TITLE
feat(config): add ECS support and runtime config hardening

### DIFF
--- a/blocky/config.yaml
+++ b/blocky/config.yaml
@@ -51,6 +51,9 @@ options:
     rewrite: []
     mapping: []
     fallback_upstream: false
+  ecs:
+    use_as_client: false
+    forward: false
   client_lookup:
     upstream: ""
     single_name_order: []
@@ -117,7 +120,7 @@ schema:
     groups:
       - name: str
         resolvers:
-          - str
+          - match(^(https://[^\s]+|(?:tcp\+udp|tcp-tls|tcp|udp):[^\s]+|[^\s:]+(?::[0-9]{1,5})?)$)
     init_strategy: list(blocking|failOnError|fast)?
     strategy: list(parallel_best|random|strict)?
     timeout: str?
@@ -151,6 +154,9 @@ schema:
         resolvers:
           - str
     fallback_upstream: bool?
+  ecs:
+    use_as_client: bool?
+    forward: bool?
   client_lookup:
     upstream: str?
     single_name_order:

--- a/blocky/rootfs/etc/cont-init.d/config.sh
+++ b/blocky/rootfs/etc/cont-init.d/config.sh
@@ -9,8 +9,15 @@ readonly ADDON_CONFIG_PATH="/config"
 bashio::log.info "Configuring Blocky..."
 
 # Create config directories
-mkdir -p "${CONFIG_PATH}"
-mkdir -p "${ADDON_CONFIG_PATH}"
+if ! mkdir -p "${CONFIG_PATH}"; then
+    bashio::log.fatal "Failed to create runtime config directory: ${CONFIG_PATH}"
+    exit 1
+fi
+
+if ! mkdir -p "${ADDON_CONFIG_PATH}"; then
+    bashio::log.fatal "Failed to create persistent config directory: ${ADDON_CONFIG_PATH}"
+    exit 1
+fi
 
 # Check if custom configuration is enabled
 if bashio::config.true 'custom_config'; then
@@ -71,6 +78,11 @@ if ! cp "${ADDON_CONFIG_PATH}/config.yml" "${CONFIG_PATH}/config.yml"; then
     exit 1
 fi
 
+if ! chmod 600 "${ADDON_CONFIG_PATH}/config.yml" "${CONFIG_PATH}/config.yml"; then
+    bashio::log.fatal "Failed to set restrictive permissions on configuration files"
+    exit 1
+fi
+
 # Create query log directory if CSV logging is enabled
 if bashio::config.has_value 'query_log.target'; then
     QUERY_LOG_TARGET=$(bashio::config 'query_log.target')
@@ -79,23 +91,29 @@ if bashio::config.has_value 'query_log.target'; then
     if [[ "${QUERY_LOG_TYPE}" == "csv" ]] || [[ "${QUERY_LOG_TYPE}" == "csv-client" ]]; then
         # Validate target path to prevent directory traversal
         if [[ "${QUERY_LOG_TARGET}" == *".."* ]]; then
-            bashio::log.warning "Query log target contains '..': ${QUERY_LOG_TARGET}"
-            bashio::log.warning "Path traversal is not allowed. Skipping directory creation."
+            bashio::log.fatal "Query log target contains '..': ${QUERY_LOG_TARGET}"
+            bashio::log.fatal "Path traversal is not allowed for CSV query logs."
+            exit 1
         elif [[ "${QUERY_LOG_TARGET}" != /config/* ]]; then
-            bashio::log.warning "Query log target must be under /config/: ${QUERY_LOG_TARGET}"
-            bashio::log.warning "Skipping directory creation."
+            bashio::log.fatal "Query log target must be under /config/: ${QUERY_LOG_TARGET}"
+            exit 1
         else
             bashio::log.info "Creating query log directory: ${QUERY_LOG_TARGET}"
             if mkdir -p "${QUERY_LOG_TARGET}"; then
                 # Verify canonical path stays within /config/ (catches symlink attacks)
                 CANONICAL_PATH=$(realpath "${QUERY_LOG_TARGET}")
                 if [[ "${CANONICAL_PATH}" != /config && "${CANONICAL_PATH}" != /config/* ]]; then
-                    bashio::log.warning "Query log directory resolves outside /config/: ${CANONICAL_PATH}"
-                    bashio::log.warning "Removing directory and skipping."
-                    rmdir "${QUERY_LOG_TARGET}" 2>/dev/null
+                    bashio::log.fatal "Query log directory resolves outside /config/: ${CANONICAL_PATH}"
+                    exit 1
                 fi
             else
-                bashio::log.warning "Failed to create query log directory: ${QUERY_LOG_TARGET}"
+                bashio::log.fatal "Failed to create query log directory: ${QUERY_LOG_TARGET}"
+                exit 1
+            fi
+
+            if [ ! -w "${QUERY_LOG_TARGET}" ]; then
+                bashio::log.fatal "Query log directory is not writable: ${QUERY_LOG_TARGET}"
+                exit 1
             fi
         fi
     fi

--- a/blocky/rootfs/usr/share/tempio/blocky.gtpl
+++ b/blocky/rootfs/usr/share/tempio/blocky.gtpl
@@ -100,18 +100,25 @@ conditional:
 {{- end }}
 {{- end }}
 
+{{- if or .ecs.use_as_client .ecs.forward }}
+# EDNS Client Subnet
+ecs:
+  useAsClient: {{ .ecs.use_as_client }}
+  forward: {{ .ecs.forward }}
+{{- end }}
+
 {{- $clientLookup := .client_lookup }}
 {{- if $clientLookup }}
 {{- $upstream := $clientLookup.upstream }}
 {{- $singleOrder := $clientLookup.single_name_order }}
 {{- $clients := $clientLookup.clients }}
-{{- if or $upstream $singleOrder $clients }}
+{{- if or $upstream $clients }}
 # Client Name Lookup
 clientLookup:
 {{- if $upstream }}
   upstream: {{ $upstream | quote }}
 {{- end }}
-{{- if $singleOrder }}
+{{- if and $upstream $singleOrder }}
   singleNameOrder:
 {{- range $order := $singleOrder }}
     - {{ $order }}

--- a/blocky/translations/en.yaml
+++ b/blocky/translations/en.yaml
@@ -147,6 +147,20 @@ configuration:
         description: >-
           Controls behavior when a conditional resolver returns an empty answer. When false (default), Blocky returns the empty result to the client. When true, Blocky falls back to normal upstream resolvers if the conditional resolver has no answer. Enable this for reliability when conditional resolvers might not have all records.
 
+  ecs:
+    name: EDNS Client Subnet (ECS)
+    description: >-
+      Controls EDNS Client Subnet behavior for upstream requests. ECS can improve CDN localization by providing client subnet hints to upstream resolvers, but it may reduce privacy because client network information is shared.
+    fields:
+      use_as_client:
+        name: Use Client Subnet
+        description: >-
+          Send the querying client subnet as ECS data to upstream resolvers when available. Improves geolocation accuracy for CDN-backed domains at the cost of additional client-network exposure.
+      forward:
+        name: Forward Existing ECS
+        description: >-
+          Forward ECS values received from downstream clients to upstream resolvers. Disable this if you want to avoid propagating downstream ECS data.
+
   client_lookup:
     name: Client Name Lookup
     description: >-


### PR DESCRIPTION
## Summary
- add EDNS Client Subnet (ECS) options to schema, template rendering, and translations for parity with upstream Blocky capabilities
- harden startup/config handling by validating base directory creation, enforcing restrictive config file permissions, and failing early on invalid/unwritable CSV query log targets
- add upstream resolver format validation and prevent rendering `clientLookup.singleNameOrder` without an explicit `clientLookup.upstream`

## Closes
- Closes #78
- Closes #128
- Closes #133
- Closes #135