### PR TITLE
docs: clarify operations, security, and migration guidance

### DIFF
--- a/blocky/DOCS.md
+++ b/blocky/DOCS.md
@@ -18,6 +18,13 @@ Configure external DNS resolvers that Blocky queries after checking blocks and c
   - `random`: Queries single random resolver (better privacy)
   - `strict`: Queries resolvers sequentially in order
 - **Timeout**: Max wait time for upstream response (default: `2s`)
+- **Init Strategy**:
+  - `blocking` (default): startup waits for upstream initialization
+  - `failOnError`: startup fails if initialization fails
+  - `fast`: startup continues while upstream checks run in background
+- **Verify Upstreams on Start** (`start_verify`): if enabled, Blocky refuses startup when no upstream is reachable.
+
+If your WAN link is unreliable, consider `init_strategy: fast` to avoid startup stalls and enable `start_verify` only when strict startup guarantees are desired.
 
 ### Bootstrap DNS
 
@@ -89,6 +96,15 @@ conditional:
         - 192.168.1.1
 ```
 
+### EDNS Client Subnet (ECS)
+
+Optional ECS forwarding controls for upstream DNS requests.
+
+- **use_as_client**: sends client subnet information to upstreams when available
+- **forward**: forwards ECS received from downstream clients
+
+ECS can improve CDN localization but may reduce privacy by sharing network location hints.
+
 ### Caching
 
 DNS response caching reduces upstream queries and improves performance.
@@ -112,11 +128,15 @@ Record DNS queries to various backends. **WARNING:** Logs contain sensitive netw
 - `mysql`, `postgresql`, `timescale`: External databases
 
 **Configuration:**
-- **Target**: Directory for CSV files (e.g., `/config/query_logs`)
+- **Target**: Directory for CSV files (e.g., `/config/query_logs`) when `type` is `csv` or `csv-client`
 - **Database**: Host, port, username, password, database name
 - **Fields**: Limit logged data (clientIP, clientName, responseReason, responseAnswer, question, duration)
 - **Retention**: Auto-delete logs older than X days (0 = keep forever)
 - **Flush Interval**: Batch write frequency (default: `30s`)
+
+Path note: `/config/...` is the container path. On the Home Assistant host, the same files are accessible under `/addon_config/<repository>_blocky/...`.
+
+For `mysql`, `postgresql`, and `timescale` types, Blocky constructs the target connection string from `db_*` fields; `target` is not used directly.
 
 ### Redis Integration
 
@@ -146,7 +166,11 @@ Resolve client IP addresses to friendly names using reverse DNS and static mappi
 
 ### Custom Config Mode
 
-Enable to use manual YAML configuration at `/addon_config/<repository>_blocky/config.yml`. All UI settings are ignored when enabled. Use for advanced Blocky features not available in UI (regex patterns, per-client rules, etc.).
+Enable to use manual YAML configuration at `/addon_config/<repository>_blocky/config.yml`.
+
+**Important:** when enabled, all UI settings are ignored. The UI remains visible due to Home Assistant limitations, but values there are not applied. Treat UI fields as read-only in this mode.
+
+Use this mode for advanced Blocky features not available in UI (regex patterns, per-client rules, etc.).
 
 ## Configuration Examples
 
@@ -259,6 +283,8 @@ query_log:
 
 Access API at `http://[HOST]:4000/api/`
 
+> **Security warning:** Blocky's API is unauthenticated. Any host with network access to port 4000 can call control endpoints. Keep the API on trusted LAN segments only.
+
 | Endpoint | Method | Parameters | Description |
 |----------|--------|------------|-------------|
 | `/blocking/status` | GET | - | Check if blocking is enabled |
@@ -281,11 +307,17 @@ curl "http://homeassistant.local:4000/api/query?query=example.com&type=A"
 
 ## Performance Tuning
 
+**Memory guidance:**
+- Absolute minimum: ~256MB for lightweight setups
+- Recommended: 512MB+ for larger blocklists, query logging, or aggressive caching
+
 **Low-memory devices (Raspberry Pi):**
 - Reduce blocklist count
 - Set `max_items_count: 5000` for cache
 - Disable query logging
 - Disable prefetching
+
+Home Assistant add-ons do not expose per-add-on CPU/RAM limits in this project today. Use Blocky cache and logging settings to control memory footprint.
 
 **High-performance networks:**
 - Enable prefetching with higher threshold
@@ -300,6 +332,14 @@ curl "http://homeassistant.local:4000/api/query?query=example.com&type=A"
 - Use DoH/DoT upstreams exclusively
 
 ## Security
+
+### Container Privileges
+
+The add-on currently runs as root inside the HA add-on sandbox because DNS binds to privileged port 53. This is common for DNS add-ons, but still a tradeoff.
+
+- Prefer strict network boundaries (LAN-only access)
+- Keep host and add-on updated
+- Avoid exposing DNS/API ports to untrusted networks
 
 ### DNS Amplification Prevention
 
@@ -332,6 +372,53 @@ DNS amplification is a type of DDoS attack where an attacker sends small DNS que
 **Note:** Home Assistant's Docker network architecture provides a layer of isolation, and the add-on's port mappings are typically only accessible from the local network. However, network configurations vary, and it is your responsibility to ensure port 53 is not exposed to the internet.
 
 ## Troubleshooting
+
+### Port 53 conflict (systemd-resolved)
+
+On some Linux hosts (especially Home Assistant Supervised), `systemd-resolved` may bind to port 53.
+
+```bash
+ss -tulnp | grep :53
+```
+
+If needed, set `DNSStubListener=no` in `/etc/systemd/resolved.conf`, restart `systemd-resolved`, then restart the add-on.
+
+### Upstreams unreachable at startup
+
+If all upstream resolvers are unreachable, startup behavior depends on upstream init settings.
+
+- `init_strategy: blocking` can delay readiness while checks run
+- `init_strategy: fast` starts DNS sooner and resolves upstream availability in background
+- `start_verify: true` fails startup when no upstream is reachable
+
+Use `fast` for unstable WAN links and verify behavior in your environment.
+
+### Blocklist source freshness
+
+Default blocklists are curated for reliability. The `sysctl.org/cameleon` source was removed because maintenance status could not be confirmed.
+
+If custom sources stop updating, Blocky logs refresh warnings. Replace stale lists with maintained alternatives.
+
+### Ingress note
+
+Ingress is not enabled by default because Blocky provides an API rather than a dedicated web UI. For authenticated remote usage, prefer Home Assistant proxying/reverse proxy with auth, or VPN access.
+
+## Upgrade and Migration Strategy
+
+### Standard mode (UI-driven)
+
+Schema migrations are handled by template/config updates shipped with the add-on. Upgrading the add-on updates generated config on restart.
+
+### Custom config mode
+
+You are responsible for adapting `/addon_config/<repository>_blocky/config.yml` when upstream Blocky schema changes.
+
+Recommended process:
+
+1. Read `blocky/CHANGELOG.md` and upstream Blocky release notes before upgrading
+2. Compare your custom config against the latest generated template output
+3. Validate manually with `blocky validate --config /etc/blocky/config.yml`
+4. Keep a backup of the last known-good custom config for rollback
 
 ### Verify Configuration
 

--- a/blocky/README.md
+++ b/blocky/README.md
@@ -83,7 +83,7 @@ For advanced users who want full control:
 2. Place your `config.yml` in `/addon_config/<repository>_blocky/`
 3. Your custom configuration will be used directly
 
-**Warning:** In custom config mode, UI settings are ignored and your configuration file will not be overwritten.
+**Warning:** In custom config mode, UI settings are ignored and your configuration file will not be overwritten. Treat the UI as read-only in this mode.
 
 ## Basic Usage
 
@@ -103,6 +103,8 @@ After installation, configure your devices or router to use Blocky:
 
 Blocky exposes an HTTP API on port 4000 (internal to Home Assistant):
 
+> **WARNING:** The API is unauthenticated. Any host that can reach port 4000 can change blocking state (for example `disable`, `enable`, `lists/refresh`). Keep it LAN-only and do not expose it to untrusted networks.
+
 - **Check blocking status:** `http://homeassistant.local:4000/api/blocking/status`
 - **Disable blocking:** `http://homeassistant.local:4000/api/blocking/disable?duration=30s`
 - **Enable blocking:** `http://homeassistant.local:4000/api/blocking/enable`
@@ -120,6 +122,8 @@ The add-on includes sensible default blocklists:
 2. **Disconnect.me Ads** - Advertising domains
 3. **Disconnect.me Tracking** - Analytics and tracking domains
 
+The previous `sysctl.org/cameleon` default source was removed because freshness/maintenance status could not be reliably verified.
+
 You can disable these or add your own custom lists in the configuration.
 
 ## Security Considerations
@@ -133,6 +137,20 @@ You can disable these or add your own custom lists in the configuration.
 - Passwords must be in plaintext in Blocky's config files (required by Blocky)
 - Configuration files are protected by container isolation and file system permissions
 - Files are only accessible within the add-on container and mounted volumes
+
+### Runtime Isolation and Privileges
+
+The add-on currently runs as root inside the Home Assistant add-on sandbox because DNS listeners bind to privileged port 53. This follows common DNS add-on patterns in HA.
+
+- Isolation relies on Home Assistant's add-on container boundaries and host network policy.
+- Treat this as defense-in-depth tradeoff: avoid unnecessary network exposure and keep Home Assistant updated.
+
+### API Access Model
+
+Ingress is not enabled by default because Blocky exposes an API surface rather than a dedicated web UI. For most users, direct LAN access to port 4000 is simpler.
+
+- If you need authenticated remote access, prefer Home Assistant proxying/reverse proxy with authentication or a VPN.
+- Do not expose port 4000 publicly.
 
 **Best Practices:**
 - Use strong, unique passwords for Redis and database connections
@@ -196,6 +214,32 @@ Recommendations:
 2. Disable query logging
 3. Reduce cache size settings
 4. Check for excessive query rates
+
+### Port 53 Already in Use (systemd-resolved)
+
+On Home Assistant Supervised or generic Linux setups, another resolver (commonly `systemd-resolved`) may already listen on port 53.
+
+1. Check listeners: `ss -tulnp | grep :53`
+2. If `systemd-resolved` is using port 53, disable DNS stub listener and restart it:
+   - Set `DNSStubListener=no` in `/etc/systemd/resolved.conf`
+   - Run `sudo systemctl restart systemd-resolved`
+3. Restart the add-on and verify it binds to port 53
+
+If you cannot free port 53, run Blocky on a non-standard port and point clients/router to that port where supported.
+
+### Low-Memory Devices (RPi Zero / 512MB and below)
+
+Guideline targets:
+
+- 256MB minimum for basic setups
+- 512MB+ recommended for larger blocklists and query logging
+
+For constrained devices:
+
+1. Keep blocklists minimal
+2. Set `caching.max_items_count` to a finite value (for example `2000-5000`)
+3. Disable prefetching and query logging when not needed
+4. Prefer `upstreams.init_strategy: fast` if startup blocking is problematic
 
 ### Can't Access Add-on Configuration
 

--- a/blocky/config.yaml
+++ b/blocky/config.yaml
@@ -65,7 +65,6 @@ options:
         sources:
           - https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt
           - https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
-          - https://sysctl.org/cameleon/hosts
       - name: tracking
         sources:
           - https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt

--- a/blocky/translations/en.yaml
+++ b/blocky/translations/en.yaml
@@ -343,7 +343,7 @@ configuration:
       target:
         name: Target Directory
         description: >-
-          Directory path for CSV log files. Only applies to csv and csv-client types. Logs are written as daily rotating files (YYYY-MM-DD.csv) in this directory. Use /config/query_logs for persistence across restarts. Directory is created automatically if it doesn't exist. Accessible via /addon_config/<repository>_blocky/query_logs/ on the Home Assistant host. Leave empty to use Blocky's default location. Not used for console or database log types. Example: /config/query_logs
+          Directory path for CSV log files. Only applies to csv and csv-client types. Logs are written as daily rotating files (YYYY-MM-DD.csv) in this directory. Use /config/query_logs for persistence across restarts. Directory is created automatically if it doesn't exist. /config/ is the container-internal path; on the Home Assistant host the same location is available under /addon_config/<repository>_blocky/ (for example /addon_config/<repository>_blocky/query_logs/). For mysql/postgresql/timescale logging, target is computed automatically from db_* fields and this option is ignored. Leave empty to use Blocky's default location for CSV logging. Example: /config/query_logs
       db_host:
         name: Database Host
         description: >-
@@ -406,4 +406,4 @@ configuration:
   custom_config:
     name: Custom Configuration Mode
     description: >-
-      Enable custom configuration mode to manually edit Blocky's configuration file directly. When enabled, all Home Assistant UI options are ignored, and you must edit the YAML file at /addon_config/<repository>_blocky/config.yml. Use this for advanced Blocky features not available in the UI, such as per-client blocking rules, query logging, regex patterns, and custom DNS records. On first enable, the add-on generates an initial config from your current UI settings as a starting point. See documentation for full details. Default: false (use UI configuration).
+      Enable custom configuration mode to manually edit Blocky's configuration file directly. WARNING: when enabled, all Home Assistant UI options are ignored and only /addon_config/<repository>_blocky/config.yml is used. Use this for advanced Blocky features not available in the UI, such as per-client blocking rules, query logging, regex patterns, and custom DNS records. On first enable, the add-on generates an initial config from your current UI settings as a starting point. See documentation for migration and operational guidance. Default: false (use UI configuration).


### PR DESCRIPTION
## Summary
- expand DOCS and README coverage for configuration options, startup/network behavior, memory guidance, and troubleshooting
- clarify custom-config mode semantics, API authentication limitations, query-log path namespaces, and CSV-vs-database target behavior
- remove stale default `sysctl.org/cameleon` source and document rationale, migration expectations, and ingress/security tradeoffs

## Closes
- Closes #71
- Closes #83
- Closes #84
- Closes #85
- Closes #86
- Closes #94
- Closes #97
- Closes #98
- Closes #127
- Closes #75
- Closes #96