### PR TITLE
fix(ci): use GitHub App token in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,18 @@ jobs:
       published: ${{ steps.semantic.outputs.new_release_published }}
       commit_sha: ${{ steps.get_sha.outputs.sha }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -68,7 +76,7 @@ jobs:
             @semantic-release/git
             @semantic-release/exec
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Get commit SHA after semantic-release
         id: get_sha


### PR DESCRIPTION
## Summary
- The `semantic_release` job fails at the `@semantic-release/git` push step because the default `GITHUB_TOKEN` cannot bypass branch protection rules on `main`
- Adds a GitHub App token generation step (via `actions/create-github-app-token@v2`) using the existing `APP_ID` and `APP_PRIVATE_KEY` secrets — the same approach already used by the deploy-dev workflow
- Uses the App token for both `actions/checkout` (so git credentials allow pushing) and the `GITHUB_TOKEN` env var passed to semantic-release

## Test plan
- [ ] Trigger the release workflow with `dry_run: true` — should succeed without attempting to push
- [ ] Trigger a real release — `@semantic-release/git` should now push the version bump commit and tags to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)