### PR TITLE
fix(ci): bypass s6 entrypoint in smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,10 +153,10 @@ jobs:
           echo "::group::Running smoke tests"
 
           # Verify Blocky binary runs
-          docker run --rm ${{ env.IMAGE_NAME }}:scan blocky version
+          docker run --rm --entrypoint blocky ${{ env.IMAGE_NAME }}:scan version
 
           # Verify Tempio is installed
-          docker run --rm ${{ env.IMAGE_NAME }}:scan tempio --version
+          docker run --rm --entrypoint tempio ${{ env.IMAGE_NAME }}:scan --version
 
           echo "::endgroup::"
           echo "::notice::Smoke tests passed"


### PR DESCRIPTION
## Summary

- Override the Docker entrypoint in the release workflow's smoke test step to bypass s6-overlay init
- Prevents failures caused by missing HA Supervisor API and `/data/options.json` during `docker run`

## Test plan

- [ ] Trigger the release workflow and verify the smoke test step passes
- [ ] Confirm `blocky version` and `tempio --version` output correctly in the workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)