### PR TITLE
feat!: drop armv7 and armhf architecture support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,13 +119,9 @@ jobs:
           # Extract base images from build.yaml for each architecture
           AMD64_BASE=$(yq '.build_from.amd64' blocky/build.yaml)
           ARM64_BASE=$(yq '.build_from.aarch64' blocky/build.yaml)
-          ARMV7_BASE=$(yq '.build_from.armv7' blocky/build.yaml)
-          ARMV6_BASE=$(yq '.build_from.armhf' blocky/build.yaml)
 
           echo "amd64_base=${AMD64_BASE}" >> $GITHUB_OUTPUT
           echo "arm64_base=${ARM64_BASE}" >> $GITHUB_OUTPUT
-          echo "armv7_base=${ARMV7_BASE}" >> $GITHUB_OUTPUT
-          echo "armv6_base=${ARMV6_BASE}" >> $GITHUB_OUTPUT
 
       - name: Set build metadata
         id: build_meta
@@ -201,7 +197,7 @@ jobs:
               --build-arg BUILD_DATE="${{ steps.build_meta.outputs.build_date }}" \
               --cache-from type=gha \
               --cache-to type=gha,mode=max \
-              blocky
+              blocky || return 1
 
             echo "::notice::Successfully built ${ARCH}"
           }
@@ -209,8 +205,6 @@ jobs:
           # Build all architectures
           build_arch amd64 linux/amd64 "${{ steps.build_config.outputs.amd64_base }}" || exit 1
           build_arch aarch64 linux/arm64 "${{ steps.build_config.outputs.arm64_base }}" || exit 1
-          build_arch armv7 linux/arm/v7 "${{ steps.build_config.outputs.armv7_base }}" || exit 1
-          build_arch armhf linux/arm/v6 "${{ steps.build_config.outputs.armv6_base }}" || exit 1
 
           echo "::endgroup::"
 
@@ -225,29 +219,21 @@ jobs:
           echo "::group::Validating architecture images"
           docker buildx imagetools inspect "${IMAGE_NAME}/amd64:${VERSION}" > /dev/null
           docker buildx imagetools inspect "${IMAGE_NAME}/aarch64:${VERSION}" > /dev/null
-          docker buildx imagetools inspect "${IMAGE_NAME}/armv7:${VERSION}" > /dev/null
-          docker buildx imagetools inspect "${IMAGE_NAME}/armhf:${VERSION}" > /dev/null
           docker buildx imagetools inspect "${IMAGE_NAME}/amd64:latest" > /dev/null
           docker buildx imagetools inspect "${IMAGE_NAME}/aarch64:latest" > /dev/null
-          docker buildx imagetools inspect "${IMAGE_NAME}/armv7:latest" > /dev/null
-          docker buildx imagetools inspect "${IMAGE_NAME}/armhf:latest" > /dev/null
           echo "::endgroup::"
 
           # Create manifest for versioned tag
           docker buildx imagetools create \
             -t "${IMAGE_NAME}:${VERSION}" \
             "${IMAGE_NAME}/amd64:${VERSION}" \
-            "${IMAGE_NAME}/aarch64:${VERSION}" \
-            "${IMAGE_NAME}/armv7:${VERSION}" \
-            "${IMAGE_NAME}/armhf:${VERSION}"
+            "${IMAGE_NAME}/aarch64:${VERSION}"
 
           # Create manifest for latest tag
           docker buildx imagetools create \
             -t "${IMAGE_NAME}:latest" \
             "${IMAGE_NAME}/amd64:latest" \
-            "${IMAGE_NAME}/aarch64:latest" \
-            "${IMAGE_NAME}/armv7:latest" \
-            "${IMAGE_NAME}/armhf:latest"
+            "${IMAGE_NAME}/aarch64:latest"
 
           echo "::endgroup::"
 
@@ -279,8 +265,6 @@ jobs:
           echo "- \`${IMAGE_NAME}:latest\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`${IMAGE_NAME}/amd64:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`${IMAGE_NAME}/aarch64:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${IMAGE_NAME}/armv7:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${IMAGE_NAME}/armhf:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
 
           echo "::endgroup::"
 
@@ -309,16 +293,12 @@ jobs:
           docker buildx imagetools inspect "${IMAGE_NAME}:${VERSION}" > /dev/null
           docker buildx imagetools inspect "${IMAGE_NAME}/amd64:${VERSION}" > /dev/null
           docker buildx imagetools inspect "${IMAGE_NAME}/aarch64:${VERSION}" > /dev/null
-          docker buildx imagetools inspect "${IMAGE_NAME}/armv7:${VERSION}" > /dev/null
-          docker buildx imagetools inspect "${IMAGE_NAME}/armhf:${VERSION}" > /dev/null
 
       - name: Repoint architecture latest tags
         run: |
           set -euo pipefail
           docker buildx imagetools create -t "${IMAGE_NAME}/amd64:latest" "${IMAGE_NAME}/amd64:${VERSION}"
           docker buildx imagetools create -t "${IMAGE_NAME}/aarch64:latest" "${IMAGE_NAME}/aarch64:${VERSION}"
-          docker buildx imagetools create -t "${IMAGE_NAME}/armv7:latest" "${IMAGE_NAME}/armv7:${VERSION}"
-          docker buildx imagetools create -t "${IMAGE_NAME}/armhf:latest" "${IMAGE_NAME}/armhf:${VERSION}"
 
       - name: Repoint multi-arch latest manifest
         run: |
@@ -326,9 +306,7 @@ jobs:
           docker buildx imagetools create \
             -t "${IMAGE_NAME}:latest" \
             "${IMAGE_NAME}/amd64:latest" \
-            "${IMAGE_NAME}/aarch64:latest" \
-            "${IMAGE_NAME}/armv7:latest" \
-            "${IMAGE_NAME}/armhf:latest"
+            "${IMAGE_NAME}/aarch64:latest"
 
       - name: Summarize rollback
         run: |

--- a/blocky/CHANGELOG.md
+++ b/blocky/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [4.0.0] - 2026-02-22
+
+### Removed
+
+- Architecture support for `armv7` and `armhf` — Home Assistant base images are no longer published for these platforms
+
 ## [3.2.0] - 2026-02-22
 
 ### Added
@@ -166,7 +172,7 @@ Additional breaking changes:
 
 See [git history](https://github.com/robocopklaus/hassio-addon-blocky/commits) for previous releases.
 
-[Unreleased]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v3.2.0...HEAD
+[4.0.0]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v3.2.0...v4.0.0
 [3.2.0]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v2.0.0...v3.0.0

--- a/blocky/Dockerfile
+++ b/blocky/Dockerfile
@@ -19,16 +19,12 @@ ARG TEMPIO_VERSION=2024.11.2
 # Example: curl -sSLf "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_<arch>" | sha256sum
 ARG TEMPIO_SHA256_AMD64=3b93ead246b3e49a616639594ec66a01e2a913193ea4462428b081b979d32243
 ARG TEMPIO_SHA256_AARCH64=01d1c8108e05b02e865286e715b05025a97f484ac694daa019323144e1d4e986
-ARG TEMPIO_SHA256_ARMV7=391666ac88a01615b7442949260f05d0e02f78cf6a13c7bb7b1be2dc24b72b48
-ARG TEMPIO_SHA256_ARMHF=78ae4e97dff2fa06bd539fa327f200be25f20978ad516c30c87b2cfd0e2b6bff
 
 # Install Tempio for config templating
 RUN \
     case "${BUILD_ARCH}" in \
         amd64) TEMPIO_SHA256="${TEMPIO_SHA256_AMD64}" ;; \
         aarch64) TEMPIO_SHA256="${TEMPIO_SHA256_AARCH64}" ;; \
-        armv7) TEMPIO_SHA256="${TEMPIO_SHA256_ARMV7}" ;; \
-        armhf) TEMPIO_SHA256="${TEMPIO_SHA256_ARMHF}" ;; \
         *) echo "Unsupported architecture: ${BUILD_ARCH}" && exit 1 ;; \
     esac \
     && \
@@ -47,10 +43,7 @@ RUN apk add --no-cache \
 RUN \
     case "${BUILD_ARCH}" in \
         amd64) ARCH="x86_64" ;; \
-        armv7) ARCH="armv7" ;; \
         aarch64) ARCH="arm64" ;; \
-        # Verified against Blocky upstream release assets: armhf maps to armv6.
-        armhf) ARCH="armv6" ;; \
         *) echo "Unsupported architecture: ${BUILD_ARCH}" && exit 1 ;; \
     esac \
     && BLOCKY_TARBALL="blocky_${BLOCKY_VERSION}_Linux_${ARCH}.tar.gz" \

--- a/blocky/README.md
+++ b/blocky/README.md
@@ -6,13 +6,9 @@
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 
 A Home Assistant add-on that wraps [Blocky](https://github.com/0xERR0R/blocky) - a fast, lightweight DNS proxy and ad-blocker for your home network with support for DNS-over-TLS, DNS-over-HTTPS, and extensive customization options.
 
@@ -279,6 +275,4 @@ MIT License - see [LICENSE](LICENSE) file for details.
 This add-on supports the following architectures:
 
 - `amd64` - Intel/AMD 64-bit (x86_64)
-- `armv7` - ARM 32-bit (ARMv7)
 - `aarch64` - ARM 64-bit (ARMv8)
-- `armhf` - ARM 32-bit (older ARM devices)

--- a/blocky/build.yaml
+++ b/blocky/build.yaml
@@ -2,9 +2,7 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
 build_from:
   amd64: ghcr.io/home-assistant/amd64-base:3.23
-  armv7: ghcr.io/home-assistant/armv7-base:3.23
   aarch64: ghcr.io/home-assistant/aarch64-base:3.23
-  armhf: ghcr.io/home-assistant/armhf-base:3.23
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Blocky"
   org.opencontainers.image.description: "Fast and lightweight DNS proxy and ad-blocker"

--- a/blocky/config.yaml
+++ b/blocky/config.yaml
@@ -4,8 +4,6 @@ slug: blocky
 description: Fast and lightweight DNS proxy and ad-blocker for your network
 url: https://github.com/robocopklaus/hassio-addon-blocky/tree/main/blocky
 arch:
-  - armhf
-  - armv7
   - amd64
   - aarch64
 image: ghcr.io/robocopklaus/hassio-addon-blocky/{arch}


### PR DESCRIPTION
## Summary

- Remove `armv7` and `armhf` architecture support — Home Assistant base images (`ghcr.io/home-assistant/{armv7,armhf}-base`) are [no longer published](https://github.com/home-assistant/docker-base/releases) for these platforms since Nov 2025, which caused the [v3.2.2 release build to fail](https://github.com/robocopklaus/hassio-addon-blocky/actions/runs/22279667046/job/64448209008)
- Fix latent error-handling bug in `release.yml` `build_arch` function — `docker buildx build` failures were silently swallowed because `set -e` is suppressed on the left side of `||`; added `|| return 1` so the function returns non-zero immediately on failure
- Clean up all armv7/armhf references from `config.yaml`, `build.yaml`, `Dockerfile`, `release.yml`, `README.md`, and `CHANGELOG.md`

## Test plan

- [ ] Verify `grep -rc 'armv7\|armhf' blocky/ .github/workflows/release.yml` returns 0 matches
- [ ] Verify `|| return 1` is present in the `build_arch` function in `release.yml`
- [ ] Run release workflow (dry run) to confirm build succeeds for amd64 and aarch64 only
- [ ] Confirm semantic-release picks up `feat!:` as a major version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)