### PR TITLE
docs: remove outdated armv7/armhf architecture references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ The template handles groups (upstreams, blocklists, clients), strategy enums, co
 ## CI/CD & Release Pipeline
 
 - **Linting** (`.github/workflows/lint.yml`): Hadolint on `blocky/Dockerfile`, ShellCheck on `blocky/rootfs/` — runs on push/PR to main
-- **Release** (`.github/workflows/release.yml`): manual trigger (`workflow_dispatch`) → semantic-release → multi-arch Docker build (amd64, aarch64, armv7, armhf) → push to GHCR
+- **Release** (`.github/workflows/release.yml`): manual trigger (`workflow_dispatch`) → semantic-release → multi-arch Docker build (amd64, aarch64) → push to GHCR
 - **Versioning**: `scripts/update-addon-version.mjs` is called by semantic-release to stamp the version into `blocky/config.yaml`
 - **Commits**: conventional commits (`feat:` → minor, `fix:` → patch, `feat(deps):` for Blocky updates, `fix(deps):` for Tempio)
 - **Dev Deploy** (`.github/workflows/deploy-dev.yml`): push to main touching `blocky/**` → syncs `blocky-dev/` with patched config → commits back to main with `[skip ci]`

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
   ![Supports amd64 Architecture](https://img.shields.io/badge/amd64-yes-green.svg)
   ![Supports aarch64 Architecture](https://img.shields.io/badge/aarch64-yes-green.svg)
-  ![Supports armv7 Architecture](https://img.shields.io/badge/armv7-yes-green.svg)
-  ![Supports armhf Architecture](https://img.shields.io/badge/armhf-yes-green.svg)
 </div>
 
 ## About
@@ -37,7 +35,7 @@ This add-on can be installed directly from the Home Assistant Add-on Store or by
 ### Requirements
 
 - Home Assistant OS or Home Assistant Supervised
-- Supported architecture: amd64, aarch64, armv7, or armhf
+- Supported architecture: amd64 or aarch64
 
 ### Basic Setup
 


### PR DESCRIPTION
## Summary

- Remove armv7 and armhf shield badges and architecture mentions from `README.md` and `CLAUDE.md`
- These architectures were dropped in v4.0.0 (#165) but the documentation still advertised them

## Test plan

- [x] Verify no remaining armv7/armhf references outside of changelogs (which correctly document the removal)
- [x] Confirm README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)