### PR TITLE
feat!: update Blocky to v0.32.1 and expose new options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,3 +96,17 @@ Always consult upstream Blocky docs as the source of truth for config options:
 - **Blocky Configuration Reference**: https://0xerr0r.github.io/blocky/latest/configuration/ (permitted for WebFetch)
 - **Blocky Official Docs**: https://0xerr0r.github.io/blocky/
 - **Home Assistant Add-on Development**: https://developers.home-assistant.io/docs/add-ons/
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in this repo's GitHub Issues, managed via the `gh` CLI. External PRs are not a triage surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical triage roles, using the default label strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/blocky/CHANGELOG.md
+++ b/blocky/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [5.0.0] - 2026-06-25
+
+### Changed
+
+- Blocky upgraded from v0.30.0 to v0.32.1
+
+### Added
+
+- DNS rebinding protection: `rebinding_protection.enable` and `rebinding_protection.allowed_domains` drop upstream answers that resolve public domains to private IP ranges (conflicts with Conditional DNS for local domains — allowlist them or keep it disabled)
+- SQLite query log: `query_log.type: sqlite` writes to a single database file, defaulting to `/config/querylog.db` (no external database required)
+- On-disk block-list download cache: `blocking.download_cache` persists downloaded lists under `/data/cache/lists` for faster restarts and resilience during source outages
+
+### Removed
+
+- **BREAKING:** the `upstreams.start_verify` option has been removed. Blocky deprecated the underlying `startVerifyUpstream` setting and folded it into the init strategy. Set `init_strategy: failOnError` to keep the "verify upstreams on start, fail if none reachable" behavior. See the migration note in DOCS.md.
+
+### Added (Upstream Blocky)
+
+- DNS rebinding protection
+- SQLite query-log target
+- Opt-in on-disk list download cache with HTTP conditional revalidation
+- Per-client DNS rate limiting
+- In-memory statistics subsystem with `/api/stats` REST endpoint
+- Sharded result cache to remove the single-lock read ceiling
+
+### Fixed (Upstream Blocky)
+
+- DNSSEC validation bypass & cache-scope pollution (GHSA-x845-2f78-7v36)
+- DNSSEC: no longer caches transient Indeterminate results; only validates public-upstream answers
+- Recursive RLock deadlock in blocking group resolution
+- Browser CORS preflight handling for custom headers and Private Network Access
+
 ## [4.2.0] - 2026-05-30
 
 ### Changed

--- a/blocky/DOCS.md
+++ b/blocky/DOCS.md
@@ -22,12 +22,13 @@ Configure external DNS resolvers that Blocky queries after checking blocks and c
 - **Timeout**: Max wait time for upstream response (default: `2s`)
 - **Init Strategy**:
   - `blocking` (default): startup waits for upstream initialization
-  - `failOnError`: startup fails if initialization fails
+  - `failOnError`: verifies upstreams on start and refuses to start if none are reachable (replaces the former `start_verify` option)
   - `fast`: startup continues while upstream checks run in background
-- **Verify Upstreams on Start** (`start_verify`): if enabled, Blocky refuses startup when no upstream is reachable.
 - **QUIC Settings**: optional DoQ idle timeout and keep-alive tuning for `quic:` upstreams.
 
-If your WAN link is unreliable, consider `init_strategy: fast` to avoid startup stalls and enable `start_verify` only when strict startup guarantees are desired.
+If your WAN link is unreliable, consider `init_strategy: fast` to avoid startup stalls, or `init_strategy: failOnError` when you want startup to fail unless an upstream is reachable.
+
+> **Migration note:** the separate `start_verify` option was removed in favor of `init_strategy: failOnError`, which Blocky now uses to express the same "verify upstreams on start" behavior. If you previously set `start_verify: true`, set `init_strategy: failOnError` instead.
 
 ### Bootstrap DNS
 
@@ -52,6 +53,7 @@ Configure domain blocking with denylists and exceptions.
   - `zeroIp` (default): Returns 0.0.0.0 (IPv4) or :: (IPv6)
   - `nxDomain`: Returns NXDOMAIN (domain doesn't exist)
 - **Block TTL**: How long clients cache blocked responses (default: `6h`)
+- **Download Cache**: Persist downloaded lists to disk (`/data/cache/lists`) so they survive restarts; uses HTTP conditional requests to skip unchanged lists and keeps serving the last good copy during source outages (default: off)
 - **Schedules**: Activate allowlist or denylist groups only on selected weekdays or time windows.
 
 For schedules, set `start` and `end` together in `HH:MM` format, or leave both empty for an all-day schedule on the selected weekdays.
@@ -138,6 +140,15 @@ Optional ECS forwarding controls for upstream DNS requests.
 
 ECS can improve CDN localization but may reduce privacy by sharing network location hints.
 
+### DNS Rebinding Protection
+
+Drop upstream answers that resolve public domains to private IP ranges (RFC 1918, link-local, loopback), returning an empty `NOERROR` response instead.
+
+- **enable**: turn protection on (default: off)
+- **allowed_domains**: domains exempt from inspection (subdomains included)
+
+**WARNING:** this inspects answers from *upstream* resolvers, so it conflicts with Conditional DNS setups that legitimately return private IPs (e.g. forwarding `fritz.box` or your local domain to your router). If you use Conditional DNS for local devices, keep this disabled or add those domains to `allowed_domains`. Custom DNS mappings are answered locally and are unaffected.
+
 ### Caching
 
 DNS response caching reduces upstream queries and improves performance.
@@ -158,10 +169,11 @@ Record DNS queries to various backends. **WARNING:** Logs contain sensitive netw
 - `csv`: Daily rotating CSV files
 - `csv-client`: Separate CSV per client
 - `console`: Output to add-on logs
+- `sqlite`: Local SQLite database file (no external server required)
 - `mysql`, `postgresql`, `timescale`: External databases
 
 **Configuration:**
-- **Target**: Directory for CSV files (e.g., `/config/query_logs`) when `type` is `csv` or `csv-client`
+- **Target**: Directory for CSV files (e.g., `/config/query_logs`) for `csv`/`csv-client`; for `sqlite`, a database file path (default `/config/querylog.db`)
 - **Database**: Host, port, username, password, database name
 - **Fields**: Limit logged data (clientIP, clientName, responseReason, responseAnswer, question, duration)
 - **Retention**: Auto-delete logs older than X days (0 = keep forever)
@@ -430,7 +442,7 @@ If all upstream resolvers are unreachable, startup behavior depends on upstream 
 
 - `init_strategy: blocking` can delay readiness while checks run
 - `init_strategy: fast` starts DNS sooner and resolves upstream availability in background
-- `start_verify: true` fails startup when no upstream is reachable
+- `init_strategy: failOnError` fails startup when no upstream is reachable
 
 Use `fast` for unstable WAN links and verify behavior in your environment.
 

--- a/blocky/Dockerfile
+++ b/blocky/Dockerfile
@@ -11,7 +11,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Setup base
 ARG BUILD_ARCH
 # renovate: datasource=github-releases depName=0xERR0R/blocky
-ARG BLOCKY_VERSION=v0.30.0
+ARG BLOCKY_VERSION=v0.32.1
 # renovate: datasource=github-releases depName=home-assistant/tempio
 ARG TEMPIO_VERSION=2024.11.2
 # IMPORTANT: Tempio does not publish checksums; update all hashes when

--- a/blocky/config.yaml
+++ b/blocky/config.yaml
@@ -36,7 +36,6 @@ options:
     init_strategy: blocking
     strategy: parallel_best
     timeout: 2s
-    start_verify: false
     quic:
       max_idle_timeout: ""
       keep_alive_period: ""
@@ -64,6 +63,9 @@ options:
     enable: false
     prefixes: []
     exclusion_set: []
+  rebinding_protection:
+    enable: false
+    allowed_domains: []
   client_lookup:
     upstream: ""
     single_name_order: []
@@ -87,6 +89,7 @@ options:
     list_schedules: []
     block_type: zeroIp
     block_ttl: 6h
+    download_cache: false
   caching:
     min_time: ""
     max_time: ""
@@ -141,7 +144,6 @@ schema:
     init_strategy: list(blocking|failOnError|fast)?
     strategy: list(parallel_best|random|strict)?
     timeout: str?
-    start_verify: bool?
     user_agent: str?
     quic:
       max_idle_timeout: str?
@@ -183,6 +185,10 @@ schema:
       - str
     exclusion_set:
       - str
+  rebinding_protection:
+    enable: bool?
+    allowed_domains:
+      - str
   client_lookup:
     upstream: str?
     single_name_order:
@@ -216,6 +222,7 @@ schema:
           - str
     block_type: match(^(zeroIp|nxDomain|((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}|([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4})(,\s*((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}|([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}))*)$)?
     block_ttl: str?
+    download_cache: bool?
   caching:
     min_time: str?
     max_time: str?
@@ -245,7 +252,7 @@ schema:
   http3:
     enable: bool?
   query_log:
-    type: list(|none|csv|csv-client|console|mysql|postgresql|timescale)?
+    type: list(|none|csv|csv-client|console|sqlite|mysql|postgresql|timescale)?
     target: str?
     db_host: str?
     db_port: int(0,65535)?

--- a/blocky/rootfs/etc/cont-init.d/config.sh
+++ b/blocky/rootfs/etc/cont-init.d/config.sh
@@ -83,39 +83,75 @@ if ! chmod 600 "${ADDON_CONFIG_PATH}/config.yml" "${CONFIG_PATH}/config.yml"; th
     exit 1
 fi
 
-# Create query log directory if CSV logging is enabled
-if bashio::config.has_value 'query_log.target'; then
-    QUERY_LOG_TARGET=$(bashio::config 'query_log.target')
-    QUERY_LOG_TYPE=$(bashio::config 'query_log.type')
+# Prepare on-disk query log storage. CSV/csv-client write daily-rotating files
+# into a target DIRECTORY; sqlite writes a single database FILE whose parent
+# directory must exist. Both must stay under /config/ for persistence.
+QUERY_LOG_TYPE=$(bashio::config 'query_log.type')
+QUERY_LOG_PATH=""
 
-    if [[ "${QUERY_LOG_TYPE}" == "csv" ]] || [[ "${QUERY_LOG_TYPE}" == "csv-client" ]]; then
-        # Validate target path to prevent directory traversal
-        if [[ "${QUERY_LOG_TARGET}" == *".."* ]]; then
-            bashio::log.fatal "Query log target contains '..': ${QUERY_LOG_TARGET}"
-            bashio::log.fatal "Path traversal is not allowed for CSV query logs."
-            exit 1
-        elif [[ "${QUERY_LOG_TARGET}" != /config/* ]]; then
-            bashio::log.fatal "Query log target must be under /config/: ${QUERY_LOG_TARGET}"
-            exit 1
-        else
-            bashio::log.info "Creating query log directory: ${QUERY_LOG_TARGET}"
-            if mkdir -p "${QUERY_LOG_TARGET}"; then
-                # Verify canonical path stays within /config/ (catches symlink attacks)
-                CANONICAL_PATH=$(realpath "${QUERY_LOG_TARGET}")
-                if [[ "${CANONICAL_PATH}" != /config && "${CANONICAL_PATH}" != /config/* ]]; then
-                    bashio::log.fatal "Query log directory resolves outside /config/: ${CANONICAL_PATH}"
-                    exit 1
-                fi
-            else
-                bashio::log.fatal "Failed to create query log directory: ${QUERY_LOG_TARGET}"
-                exit 1
-            fi
-
-            if [ ! -w "${QUERY_LOG_TARGET}" ]; then
-                bashio::log.fatal "Query log directory is not writable: ${QUERY_LOG_TARGET}"
-                exit 1
-            fi
+case "${QUERY_LOG_TYPE}" in
+    csv | csv-client)
+        # target is the directory that holds the daily-rotating files
+        if bashio::config.has_value 'query_log.target'; then
+            QUERY_LOG_PATH=$(bashio::config 'query_log.target')
         fi
+        ;;
+    sqlite)
+        # target is the database file; default must match the blocky.gtpl fallback
+        if bashio::config.has_value 'query_log.target'; then
+            QUERY_LOG_PATH=$(bashio::config 'query_log.target')
+        else
+            QUERY_LOG_PATH="/config/querylog.db"
+        fi
+        ;;
+esac
+
+if [ -n "${QUERY_LOG_PATH}" ]; then
+    # Validate the full target path (the value Blocky writes to) to prevent
+    # directory traversal and keep query logs under /config/.
+    if [[ "${QUERY_LOG_PATH}" == *".."* ]]; then
+        bashio::log.fatal "Query log target contains '..': ${QUERY_LOG_PATH}"
+        bashio::log.fatal "Path traversal is not allowed for query logs."
+        exit 1
+    elif [[ "${QUERY_LOG_PATH}" != /config && "${QUERY_LOG_PATH}" != /config/* ]]; then
+        bashio::log.fatal "Query log target must be under /config/: ${QUERY_LOG_PATH}"
+        exit 1
+    fi
+
+    # sqlite target is a file -> create its parent dir; csv target is the dir itself
+    if [[ "${QUERY_LOG_TYPE}" == "sqlite" ]]; then
+        QUERY_LOG_DIR=$(dirname "${QUERY_LOG_PATH}")
+    else
+        QUERY_LOG_DIR="${QUERY_LOG_PATH}"
+    fi
+
+    bashio::log.info "Creating query log directory: ${QUERY_LOG_DIR}"
+    if ! mkdir -p "${QUERY_LOG_DIR}"; then
+        bashio::log.fatal "Failed to create query log directory: ${QUERY_LOG_DIR}"
+        exit 1
+    fi
+
+    # Verify canonical path stays within /config/ (catches symlink attacks)
+    CANONICAL_PATH=$(realpath "${QUERY_LOG_DIR}")
+    if [[ "${CANONICAL_PATH}" != /config && "${CANONICAL_PATH}" != /config/* ]]; then
+        bashio::log.fatal "Query log directory resolves outside /config/: ${CANONICAL_PATH}"
+        exit 1
+    fi
+
+    if [ ! -w "${QUERY_LOG_DIR}" ]; then
+        bashio::log.fatal "Query log directory is not writable: ${QUERY_LOG_DIR}"
+        exit 1
+    fi
+fi
+
+# Create the on-disk block list download cache directory when enabled.
+# Internal, regenerable state -> lives under /data (add-on-private), see ADR-0001.
+if bashio::config.true 'blocking.download_cache'; then
+    readonly LIST_CACHE_DIR="/data/cache/lists"
+    bashio::log.info "Creating block list download cache directory: ${LIST_CACHE_DIR}"
+    if ! mkdir -p "${LIST_CACHE_DIR}"; then
+        bashio::log.fatal "Failed to create list download cache directory: ${LIST_CACHE_DIR}"
+        exit 1
     fi
 fi
 

--- a/blocky/rootfs/usr/share/tempio/blocky.gtpl
+++ b/blocky/rootfs/usr/share/tempio/blocky.gtpl
@@ -34,9 +34,6 @@ upstreams:
     keepAlivePeriod: {{ $quic.keep_alive_period | quote }}
 {{- end }}
 {{- end }}
-{{- if .upstreams.start_verify }}
-  startVerifyUpstream: true
-{{- end }}
 {{- if .upstreams.user_agent }}
   userAgent: {{ .upstreams.user_agent | quote }}
 {{- end }}
@@ -130,6 +127,18 @@ dns64:
 {{- if .dns64.exclusion_set }}
   exclusionSet:
 {{- range .dns64.exclusion_set }}
+    - {{ . | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- if .rebinding_protection.enable }}
+# DNS Rebinding Protection
+rebindingProtection:
+  enable: true
+{{- if .rebinding_protection.allowed_domains }}
+  allowedDomains:
+{{- range .rebinding_protection.allowed_domains }}
     - {{ . | quote }}
 {{- end }}
 {{- end }}
@@ -245,6 +254,11 @@ blocking:
 {{- if $blocking.block_ttl }}
   blockTTL: {{ $blocking.block_ttl | quote }}
 {{- end }}
+{{- if $blocking.download_cache }}
+  loading:
+    downloads:
+      cachePath: "/data/cache/lists"
+{{- end }}
 {{- end }}
 {{- end }}
 
@@ -319,6 +333,9 @@ queryLog:
 {{- if $queryLog.target }}
   target: {{ $queryLog.target | quote }}
 {{- end }}
+{{- end }}
+{{- if eq $queryLog.type "sqlite" }}
+  target: {{ if $queryLog.target }}{{ $queryLog.target | quote }}{{ else }}"/config/querylog.db"{{ end }}
 {{- end }}
 {{- if or (eq $queryLog.type "mysql") (eq $queryLog.type "postgresql") (eq $queryLog.type "timescale") }}
 {{- if and $queryLog.db_host $queryLog.db_database }}

--- a/blocky/translations/en.yaml
+++ b/blocky/translations/en.yaml
@@ -12,7 +12,7 @@ configuration:
       init_strategy:
         name: Init Strategy
         description: >-
-          Tests the configured resolvers for each group on initialization. Strategies: blocking (default, initialization completes before DNS starts, errors are logged but continues if possible), failOnError (like blocking but exits on failure), or fast (DNS starts immediately, initialization happens in background).
+          Tests the configured resolvers for each group on initialization. Strategies: blocking (default, initialization completes before DNS starts, errors are logged but continues if possible), failOnError (verifies upstreams on start and refuses to start if none are reachable - use this instead of the former "Verify Upstreams on Start" option), or fast (DNS starts immediately, initialization happens in background).
       strategy:
         name: Strategy
         description: >-
@@ -21,12 +21,6 @@ configuration:
         name: Timeout
         description: >-
           Maximum time to wait for a response from upstream DNS servers before considering them unreachable. Controls how long Blocky waits before marking an upstream resolver as failed and trying the next one. Format: duration string like 2s (2 seconds), 5s (5 seconds), or 500ms (500 milliseconds). Default: 2s if not specified. Increase for slow or distant resolvers (satellite internet, VPN), decrease for faster failure detection in local networks.
-      start_verify:
-        name: Verify Upstreams on Start
-        description: >-
-          When enabled, Blocky verifies that configured upstream DNS servers are
-          reachable during startup. If no upstream is reachable, Blocky will fail
-          to start instead of running with broken DNS resolution.
       quic:
         name: DNS-over-QUIC Settings
         description: >-
@@ -192,6 +186,20 @@ configuration:
         description: >-
           IPv6 address ranges excluded from DNS64 synthesis. Queries resolving to addresses in these ranges will not trigger DNS64 synthesis. Leave empty to use Blocky's default exclusion set (recommended). Only customize for advanced network configurations with specific exclusion requirements.
 
+  rebinding_protection:
+    name: DNS Rebinding Protection
+    description: >-
+      Protect against DNS rebinding attacks by dropping upstream answers that resolve public domains to private IP ranges (RFC 1918, link-local, loopback). When triggered, Blocky returns an empty NOERROR response instead of the private address. WARNING: This inspects answers returned by UPSTREAM resolvers, so it conflicts with Conditional DNS setups that legitimately return private IPs (for example forwarding fritz.box or your local domain to your router). If you use Conditional DNS for local devices, either keep this disabled or add those domains to the Allowed Domains list below. Does not affect Custom DNS mappings, which are answered locally. Default: disabled.
+    fields:
+      enable:
+        name: Enable Rebinding Protection
+        description: >-
+          Activate DNS rebinding protection. When true, upstream answers pointing public domains at private/local IP addresses are dropped and returned as empty NOERROR. Default: false (disabled).
+      allowed_domains:
+        name: Allowed Domains
+        description: >-
+          Domains exempt from rebinding inspection. Add domains that are expected to resolve to private IPs through your upstream or conditional resolvers (for example your router's local domain like fritz.box, or an intranet domain). Subdomains are included automatically. Leave empty to inspect all domains.
+
   client_lookup:
     name: Client Name Lookup
     description: >-
@@ -305,6 +313,10 @@ configuration:
         name: Block Response TTL
         description: >-
           Time-To-Live (cache duration) for blocked domain responses. Controls how long clients cache blocked responses before re-querying. Format: duration string like 10s (10 seconds), 5m (5 minutes), or 6h (6 hours). Default: 6h. Lower values (e.g., 10s, 1m) allow faster recovery after removing domains from blocklists; higher values (e.g., 12h, 24h) reduce DNS query load for frequently blocked domains. Only applies when using zeroIp or nxDomain block types. Default: 6h.
+      download_cache:
+        name: Cache Downloaded Lists on Disk
+        description: >-
+          Persist downloaded block/allow lists to disk so they survive restarts. When enabled, Blocky uses HTTP conditional requests to skip re-downloading unchanged lists (faster startup) and keeps serving the last good copy if a source is temporarily unreachable. The cache is stored internally at /data/cache/lists (add-on-private, persists across restarts and updates) and is fully regenerable, so it is not exposed in your config folder. Default: false (downloads are stateless).
 
   caching:
     name: Caching
@@ -432,11 +444,11 @@ configuration:
       type:
         name: Log Type
         description: >-
-          Storage backend for query logs. Options: "" (blank, disabled by default - no logging), none (explicit disable, equivalent to blank), csv (daily rotating CSV files in target directory), csv-client (separate daily CSV file per client for organized analysis), console (output to add-on logs, visible in Home Assistant), mysql (external MySQL/MariaDB database), postgresql (external PostgreSQL database), timescale (external Timescale database for time-series optimization). CSV logs are stored in the /config directory by default. Database options require external database setup with connection details below. Default: "" (blank, disabled).
+          Storage backend for query logs. Options: "" (blank, disabled by default - no logging), none (explicit disable, equivalent to blank), csv (daily rotating CSV files in target directory), csv-client (separate daily CSV file per client for organized analysis), console (output to add-on logs, visible in Home Assistant), sqlite (local SQLite database file, no external server required - the simplest persistent option), mysql (external MySQL/MariaDB database), postgresql (external PostgreSQL database), timescale (external Timescale database for time-series optimization). CSV and SQLite logs are stored in the /config directory by default. Database options require external database setup with connection details below. Default: "" (blank, disabled).
       target:
-        name: Target Directory
+        name: Target Path
         description: >-
-          Directory path for CSV log files. Only applies to csv and csv-client types. Logs are written as daily rotating files (YYYY-MM-DD.csv) in this directory. Use /config/query_logs for persistence across restarts. Directory is created automatically if it doesn't exist. /config/ is the container-internal path; on the Home Assistant host the same location is available under /addon_config/<repository>_blocky/ (for example /addon_config/<repository>_blocky/query_logs/). For mysql/postgresql/timescale logging, target is computed automatically from db_* fields and this option is ignored. Leave empty to use Blocky's default location for CSV logging. Example: /config/query_logs
+          For csv and csv-client types this is a DIRECTORY for daily rotating files (YYYY-MM-DD.csv); for sqlite it is a single database FILE path. Use a location under /config/ for persistence across restarts; the directory is created automatically if it doesn't exist. /config/ is the container-internal path; on the Home Assistant host the same location is available under /addon_config/<repository>_blocky/ (for example /addon_config/<repository>_blocky/query_logs/). For sqlite, leave empty to use the default /config/querylog.db (Blocky also creates -wal and -shm side files). For mysql/postgresql/timescale logging, target is computed automatically from db_* fields and this option is ignored. Leave empty to use Blocky's default location for CSV logging. Examples: /config/query_logs (csv) or /config/querylog.db (sqlite)
       db_host:
         name: Database Host
         description: >-

--- a/docs/adr/0001-persistent-storage-path-convention.md
+++ b/docs/adr/0001-persistent-storage-path-convention.md
@@ -1,0 +1,7 @@
+# Persistent storage paths for generated artifacts
+
+The add-on translates HA options into Blocky config and must place Blocky's runtime artifacts on persistent storage that survives container restarts and add-on updates. We route **user-facing data the operator may want to read or manage** (CSV/SQLite query logs) under `/config/` — the `addon_config:rw`-mapped, user-visible folder — with a hard `/config/`-containment check in `config.sh` to prevent path traversal. We route **purely internal, regenerable state** (the on-disk block-list download cache) under `/data/` — the add-on-private dir that persists across updates but is hidden from the user — so it never clutters the operator's visible config folder.
+
+**Considered & rejected:** putting the list cache under `/config/` too (consistent single location). Rejected because the cache is regenerable noise the user should never see or edit, and `/data/` already exists for exactly this kind of private persistent state.
+
+**Consequence:** new features follow this split — ask "would the operator ever want to look at this file?" `/config/` if yes, `/data/` if no.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,34 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary

Updates Blocky **v0.30.0 → v0.32.1** and incorporates the relevant upstream changes into the add-on. Supersedes Renovate #237 (which only bumped the version pin and would have shipped a config the new validator rejects).

### New HA options
- **DNS rebinding protection** — `rebinding_protection.enable` + `allowed_domains`. Drops upstream answers resolving public domains to private IPs. ⚠️ Conflicts with Conditional DNS for local domains (e.g. forwarding `fritz.box` to your router) — allowlist them or keep it disabled. Default off.
- **SQLite query log** — `query_log.type: sqlite`, writing to a single DB file (default `/config/querylog.db`, no external DB needed).
- **On-disk list download cache** — `blocking.download_cache` toggle → `/data/cache/lists`. Faster restarts + resilience during source outages.

### Breaking change
Blocky 0.31.0's schema-driven validation **rejects** the previously-emitted `upstreams.startVerifyUpstream` key (hard error → add-on would fail to start). Blocky folded "verify upstreams on start" into the init strategy, so:

- **`start_verify` removed** → use `init_strategy: failOnError` instead (same behavior). Migration note in DOCS.md + CHANGELOG.md.

This is why the change is `feat!` (major: **5.0.0**).

### Storage path convention (ADR-0001)
User-facing data (query logs) under `/config/`; internal regenerable cache under `/data/`. `config.sh` validates the full query-log target (path traversal + `/config/` containment) before creating directories.

## Verification
Rendered the template with both **default** and **maximal** option sets and ran `blocky validate` (native darwin binaries) — both clean, exit 0, no deprecation warnings. All three new features emit correct YAML.

## Review
High-effort workflow review (32 agents, 22 candidate findings → 8 verified). Fixed: sqlite path validation (validate full target, not just dirname), download-cache-only emitting an empty `blocking:` block, and stale `start_verify` doc references. Custom-config-mode dir-creation gaps and path-duplication noted as pre-existing/low-severity.

## Docs
DOCS.md (migration + 3 feature sections), CHANGELOG.md (`[5.0.0]`), translations/en.yaml. Add-on `version:` is stamped by semantic-release on release — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)