### PR TITLE
chore(config): auto-merge minor updates and fix automerge mechanism

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,7 +41,36 @@
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {
-      "description": "Blocky updates trigger version bump",
+      "description": "Auto-merge patch and minor updates via GitHub native auto-merge (waits for required checks). Later package-specific rules opt specific deps back out.",
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "description": "Group Home Assistant base images and keep them manual (base image changes affect the runtime)",
+      "matchDatasources": [
+        "docker"
+      ],
+      "groupName": "Home Assistant base images",
+      "matchPackageNames": [
+        "/^ghcr.io/home-assistant/.*-base$/"
+      ],
+      "automerge": false
+    },
+    {
+      "description": "Group semantic-release packages",
+      "groupName": "semantic-release packages",
+      "matchPackageNames": [
+        "/^@semantic-release//",
+        "/^semantic-release$/"
+      ]
+    },
+    {
+      "description": "Blocky updates trigger a version bump and require manual review",
       "matchDatasources": [
         "github-releases"
       ],
@@ -52,7 +81,7 @@
       "automerge": false
     },
     {
-      "description": "Tempio updates trigger patch bump",
+      "description": "Tempio updates trigger a patch bump and require manual review",
       "matchDatasources": [
         "github-releases"
       ],
@@ -61,32 +90,6 @@
       ],
       "commitMessagePrefix": "fix(deps):",
       "automerge": false
-    },
-    {
-      "description": "Auto-merge patch updates only",
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "automerge": true,
-      "automergeType": "branch"
-    },
-    {
-      "description": "Group Home Assistant base images",
-      "matchDatasources": [
-        "docker"
-      ],
-      "groupName": "Home Assistant base images",
-      "matchPackageNames": [
-        "/^ghcr.io/home-assistant/.*-base$/"
-      ]
-    },
-    {
-      "description": "Group semantic-release packages",
-      "groupName": "semantic-release packages",
-      "matchPackageNames": [
-        "/^@semantic-release//",
-        "/^semantic-release$/"
-      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Lets Renovate auto-merge **minor** updates in addition to patch, and fixes two latent issues in the automerge config.

### What changes
- **patch + minor** updates auto-merge (was patch-only). Major still requires manual review.
- **`automergeType` switched `branch` → `pr` + `platformAutomerge: true`.** The `main` branch ruleset requires a PR (no direct pushes) and three status checks (ShellCheck, Hadolint, Config Contract), so `branch`-type automerge could never actually fire. PR-based GitHub native auto-merge waits for the required checks, then merges.
- **`packageRules` reordered** so package-specific manual-review guards come *after* the broad auto-merge rule and therefore win (Renovate applies later rules with higher precedence). Previously the patch-automerge rule sat after the Blocky/Tempio guards and would have overridden their `automerge: false` for patch-type updates.

### Kept manual (require review)
- **Major** updates
- **Blocky** (`0xERR0R/blocky`) — triggers add-on version bump
- **Tempio** (`home-assistant/tempio`) — affects config rendering
- **Home Assistant base images** — affect the runtime

So minor/patch bumps to node, pnpm, semantic-release, and GitHub Actions flow through automatically; anything with runtime/version impact stays gated.

> Note: a Renovate config change only takes effect once it's on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)