### PR TITLE
ci: sync blocky-dev reliably with rsync --checksum

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -30,7 +30,12 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Sync blocky → blocky-dev
-        run: rsync -a --delete blocky/ blocky-dev/
+        # --checksum: compare file contents, not size+mtime. On a fresh
+        # checkout all files share the same mtime, and same-length edits (e.g.
+        # the Dockerfile BLOCKY_VERSION string: v0.29.0 -> v0.32.1) keep the
+        # same size, so the default size+mtime heuristic skips them and leaves
+        # blocky-dev stale.
+        run: rsync -a --delete --checksum blocky/ blocky-dev/
 
       - name: Patch blocky-dev/config.yaml
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ test/
 # Local config
 config.local.yaml
 secrets.yaml
+.hass_config
 
 # JavaScript/TypeScript deps
 node_modules/

--- a/blocky-dev/Dockerfile
+++ b/blocky-dev/Dockerfile
@@ -11,7 +11,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Setup base
 ARG BUILD_ARCH
 # renovate: datasource=github-releases depName=0xERR0R/blocky
-ARG BLOCKY_VERSION=v0.29.0
+ARG BLOCKY_VERSION=v0.32.1
 # renovate: datasource=github-releases depName=home-assistant/tempio
 ARG TEMPIO_VERSION=2024.11.2
 # IMPORTANT: Tempio does not publish checksums; update all hashes when


### PR DESCRIPTION
## Problem

The Deploy Dev workflow synced `blocky/` → `blocky-dev/` with `rsync -a --delete`, which decides whether to copy a file using **size + mtime**. On a fresh CI checkout all files share the same mtime, and the only change in the Dockerfile between Blocky releases is the version string — which keeps the **same byte length** (`v0.29.0` → `v0.30.0` → `v0.32.1`, all 7 chars). rsync therefore **skipped the Dockerfile**, leaving `blocky-dev` stuck on **Blocky v0.29.0 since #188** while config/template/docs synced fine.

Result: the dev add-on has the new 5.0.0 config/template layer but an ancient Blocky binary — a broken hybrid (the new template emits `rebindingProtection` etc., which v0.29.0 rejects).

## Fix
- Add `--checksum` to the rsync so it compares file **content**, not size+mtime. Prevents this and any future same-length drift.
- Bump the stale `blocky-dev/Dockerfile` to **v0.32.1** to match `blocky/` immediately.
- Gitignore `.hass_config` (local Home Assistant CLI token file).

Typed `ci:` so it does not trigger a release. After merge, the Deploy Dev run (triggered by the workflow change) re-syncs with `--checksum` and confirms `blocky-dev` matches `blocky/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)