### PR TITLE
fix: keep start_verify as a deprecated option for zero-touch upgrades

### DIFF
--- a/blocky/CHANGELOG.md
+++ b/blocky/CHANGELOG.md
@@ -16,9 +16,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - SQLite query log: `query_log.type: sqlite` writes to a single database file, defaulting to `/config/querylog.db` (no external database required)
 - On-disk block-list download cache: `blocking.download_cache` persists downloaded lists under `/data/cache/lists` for faster restarts and resilience during source outages
 
-### Removed
+### Deprecated
 
-- **BREAKING:** the `upstreams.start_verify` option has been removed. Blocky deprecated the underlying `startVerifyUpstream` setting and folded it into the init strategy. Set `init_strategy: failOnError` to keep the "verify upstreams on start, fail if none reachable" behavior. See the migration note in DOCS.md.
+- `upstreams.start_verify` is deprecated. Blocky folded the underlying `startVerifyUpstream` setting into the init strategy. The option is **still accepted** so existing configurations keep working unchanged, and `start_verify: true` is automatically mapped to `init_strategy: failOnError`. Switch to `init_strategy` at your convenience; `start_verify` will be removed in a future major release.
 
 ### Added (Upstream Blocky)
 

--- a/blocky/DOCS.md
+++ b/blocky/DOCS.md
@@ -22,13 +22,14 @@ Configure external DNS resolvers that Blocky queries after checking blocks and c
 - **Timeout**: Max wait time for upstream response (default: `2s`)
 - **Init Strategy**:
   - `blocking` (default): startup waits for upstream initialization
-  - `failOnError`: verifies upstreams on start and refuses to start if none are reachable (replaces the former `start_verify` option)
+  - `failOnError`: verifies upstreams on start and refuses to start if none are reachable (use this instead of the deprecated `start_verify`)
   - `fast`: startup continues while upstream checks run in background
+- **Verify Upstreams on Start** (`start_verify`): **deprecated** — kept for backward compatibility. When enabled it is mapped to `init_strategy: failOnError`. Prefer setting Init Strategy directly.
 - **QUIC Settings**: optional DoQ idle timeout and keep-alive tuning for `quic:` upstreams.
 
 If your WAN link is unreliable, consider `init_strategy: fast` to avoid startup stalls, or `init_strategy: failOnError` when you want startup to fail unless an upstream is reachable.
 
-> **Migration note:** the separate `start_verify` option was removed in favor of `init_strategy: failOnError`, which Blocky now uses to express the same "verify upstreams on start" behavior. If you previously set `start_verify: true`, set `init_strategy: failOnError` instead.
+> **Migration note:** Blocky folded "verify upstreams on start" into the init strategy, so the separate `start_verify` option is **deprecated**. It is still accepted — existing configurations keep working unchanged, and `start_verify: true` is automatically mapped to `init_strategy: failOnError`. No action is required; switch to `init_strategy` at your convenience. `start_verify` will be removed in a future major release.
 
 ### Bootstrap DNS
 

--- a/blocky/config.yaml
+++ b/blocky/config.yaml
@@ -36,6 +36,7 @@ options:
     init_strategy: blocking
     strategy: parallel_best
     timeout: 2s
+    start_verify: false
     quic:
       max_idle_timeout: ""
       keep_alive_period: ""
@@ -144,6 +145,7 @@ schema:
     init_strategy: list(blocking|failOnError|fast)?
     strategy: list(parallel_best|random|strict)?
     timeout: str?
+    start_verify: bool?
     user_agent: str?
     quic:
       max_idle_timeout: str?

--- a/blocky/rootfs/usr/share/tempio/blocky.gtpl
+++ b/blocky/rootfs/usr/share/tempio/blocky.gtpl
@@ -14,9 +14,15 @@ upstreams:
       - {{ . | quote }}
 {{- end }}
 {{- end }}
-{{- if .upstreams.init_strategy }}
+{{- /* start_verify is deprecated: Blocky folded "verify upstreams on start" into the init strategy.
+       Map a legacy start_verify:true onto init.strategy=failOnError so existing configs keep working. */}}
+{{- $initStrategy := .upstreams.init_strategy }}
+{{- if .upstreams.start_verify }}
+{{- $initStrategy = "failOnError" }}
+{{- end }}
+{{- if $initStrategy }}
   init:
-    strategy: {{ .upstreams.init_strategy | quote }}
+    strategy: {{ $initStrategy | quote }}
 {{- end }}
 {{- if .upstreams.strategy }}
   strategy: {{ .upstreams.strategy | quote }}

--- a/blocky/translations/en.yaml
+++ b/blocky/translations/en.yaml
@@ -12,7 +12,7 @@ configuration:
       init_strategy:
         name: Init Strategy
         description: >-
-          Tests the configured resolvers for each group on initialization. Strategies: blocking (default, initialization completes before DNS starts, errors are logged but continues if possible), failOnError (verifies upstreams on start and refuses to start if none are reachable - use this instead of the former "Verify Upstreams on Start" option), or fast (DNS starts immediately, initialization happens in background).
+          Tests the configured resolvers for each group on initialization. Strategies: blocking (default, initialization completes before DNS starts, errors are logged but continues if possible), failOnError (verifies upstreams on start and refuses to start if none are reachable - use this instead of the deprecated "Verify Upstreams on Start" option), or fast (DNS starts immediately, initialization happens in background).
       strategy:
         name: Strategy
         description: >-
@@ -21,6 +21,10 @@ configuration:
         name: Timeout
         description: >-
           Maximum time to wait for a response from upstream DNS servers before considering them unreachable. Controls how long Blocky waits before marking an upstream resolver as failed and trying the next one. Format: duration string like 2s (2 seconds), 5s (5 seconds), or 500ms (500 milliseconds). Default: 2s if not specified. Increase for slow or distant resolvers (satellite internet, VPN), decrease for faster failure detection in local networks.
+      start_verify:
+        name: Verify Upstreams on Start (deprecated)
+        description: >-
+          DEPRECATED - use Init Strategy "failOnError" instead. Kept for backward compatibility so existing configurations keep working without changes. When enabled, it is mapped to init strategy "failOnError" (Blocky refuses to start if no upstream is reachable). Leave disabled and set Init Strategy directly. This option will be removed in a future release.
       quic:
         name: DNS-over-QUIC Settings
         description: >-


### PR DESCRIPTION
## Why

#242 **removed** the `start_verify` option. That breaks the v4 → v5 **auto-update** for existing users: Home Assistant validates stored add-on options against the new schema, and a now-unknown `start_verify` key makes the add-on fail with *"configuration invalid"* until the user manually edits it. The stable add-on has `auto_update: true`, so a release would push that breakage to every install — exactly the "users must do something" outcome we want to avoid.

(Confirmed against a real stable config, which contains `upstreams.start_verify: false`.)

## What

Deprecate `start_verify` instead of removing it:

- **Schema/options:** re-add `start_verify` (`bool?`, default `false`) so stored v4 configs stay valid — no Supervisor schema error on update.
- **Template:** map it onto the modern setting — `start_verify: true` → `upstreams.init.strategy: failOnError` (preserves the old "verify on start, fail if none reachable" behavior). The deprecated `startVerifyUpstream` key (which Blocky 0.32 rejects) is never emitted again.
- **Docs/UI:** marked deprecated in `translations/en.yaml`, `DOCS.md`, and `CHANGELOG.md`, pointing users to `init_strategy`. Actual removal deferred to a future major.

Net effect: **v4 → v5 is now zero-touch.** 5.0.0 stays a major release (big Blocky jump + new features) but requires no config changes from users.

## Verification (native blocky v0.32.1)
- `start_verify: true` → emits `init.strategy: failOnError` → valid
- `start_verify: false` → emits the configured `init_strategy` → valid
- A real-world v4 stable config (with `start_verify: false` present) renders and validates clean, unchanged.

Supersedes the "Removed (BREAKING)" framing from #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)