### PR TITLE
fix: harden config translation against invalid combinations

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,41 @@
+# Blocky Home Assistant Add-on
+
+A containerized integration layer that translates Home Assistant add-on options into Blocky's native YAML. The domain language here is about *that translation* — modes, rendering, and how invalid input is handled — not about DNS resolution itself (that's Blocky's domain, see the upstream Blocky docs).
+
+## Language
+
+### Configuration modes
+
+**Standard Mode**:
+The default. HA UI options are rendered through the Tempio template into the runtime config on every restart.
+_Avoid_: default mode, UI mode
+
+**Custom Config Mode**:
+The operator supplies a complete Blocky YAML; template rendering is bypassed entirely and UI options are ignored. Generated once on first run, then preserved.
+_Avoid_: manual mode, advanced mode, expert mode
+
+### Translation pipeline
+
+**Rendered config**:
+The generated `/etc/blocky/config.yml` — the single source of truth and the actual contract with the Blocky binary. Guards validate *this*, never a re-derivation of the options.
+_Avoid_: output config, generated YAML (when precision matters)
+
+**Guard**:
+A check in a `cont-init.d` script that inspects the rendered config (or prepares its on-disk dependencies) before Blocky starts, and either aborts or degrades on a problem. Distinct from the template's own conditional gating.
+_Avoid_: validator, check
+
+### Failure policy (see ADR-0002)
+
+**Core feature**:
+A feature without which Blocky cannot resolve DNS at all (e.g. `upstreams`, `bootstrap`). A broken core feature is fail-fast: the add-on logs a clear error and aborts.
+_Avoid_: required feature, essential feature
+
+**Side feature**:
+A feature DNS resolution survives without (e.g. `https`/DoH, `prometheus`, `redis`, `query_log`, `blocking`). A broken side feature degrades: the template omits it so the rendered YAML stays valid, and a guard warns.
+_Avoid_: optional feature, secondary feature
+
+### Blocking vocabulary
+
+**Denylist** / **Allowlist**:
+Named groups of block/exception sources. The add-on standardizes on these terms throughout schema, UI, and template.
+_Avoid_: blacklist, whitelist, blocklist

--- a/blocky/rootfs/etc/cont-init.d/config.sh
+++ b/blocky/rootfs/etc/cont-init.d/config.sh
@@ -85,28 +85,32 @@ if ! chmod 600 "${ADDON_CONFIG_PATH}/config.yml" "${CONFIG_PATH}/config.yml"; th
     exit 1
 fi
 
+# HTTPS/DoH is a side feature (ADR-0002): when enabled without a certificate the
+# template drops it rather than open :443 with no cert (which would crash Blocky).
+# Warn so the degrade is not silent. DNS resolution is unaffected.
+if bashio::config.true 'https.enable' || bashio::config.true 'http3.enable'; then
+    if ! bashio::config.has_value 'https.cert_file' || ! bashio::config.has_value 'https.key_file'; then
+        bashio::log.warning "HTTPS/DoH/HTTP3 requested but cert_file and key_file are not both set."
+        bashio::log.warning "TLS is disabled and port 443 will not be opened. DNS resolution continues normally."
+    fi
+fi
+
 # Prepare on-disk query log storage. CSV/csv-client write daily-rotating files
 # into a target DIRECTORY; sqlite writes a single database FILE whose parent
 # directory must exist. Both must stay under /config/ for persistence.
+#
+# Read the effective target from the RENDERED config (the single source of
+# truth, see ADR-0002). We never re-derive the default path here: that would
+# duplicate the template's fallback and silently drift from the path Blocky
+# actually writes to. The coupling is narrow (one machine-generated line) and
+# fails loudly (empty path slips through to the containment check below).
 QUERY_LOG_TYPE=$(bashio::config 'query_log.type')
 QUERY_LOG_PATH=""
 
 case "${QUERY_LOG_TYPE}" in
-    csv | csv-client)
-        # target is the directory that holds the daily-rotating files
-        if bashio::config.has_value 'query_log.target'; then
-            QUERY_LOG_PATH=$(bashio::config 'query_log.target')
-        else
-            QUERY_LOG_PATH="/config/query_logs"
-        fi
-        ;;
-    sqlite)
-        # target is the database file; default must match the blocky.gtpl fallback
-        if bashio::config.has_value 'query_log.target'; then
-            QUERY_LOG_PATH=$(bashio::config 'query_log.target')
-        else
-            QUERY_LOG_PATH="/config/querylog.db"
-        fi
+    csv | csv-client | sqlite)
+        QUERY_LOG_PATH=$(sed -n 's/^[[:space:]]*target:[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' \
+            "${CONFIG_PATH}/config.yml" | head -n1)
         ;;
 esac
 

--- a/blocky/rootfs/usr/share/tempio/blocky.gtpl
+++ b/blocky/rootfs/usr/share/tempio/blocky.gtpl
@@ -376,8 +376,12 @@ queryLog:
 {{- end }}
 {{- end }}
 
-{{- $httpsEnabled := or .https.enable .http3.enable }}
-{{- if and $httpsEnabled .https.cert_file .https.key_file }}
+{{- $httpsRequested := or .https.enable .http3.enable }}
+{{- /* TLS needs both cert and key. Without them we drop HTTPS/DoH entirely
+       (a side feature, see ADR-0002) rather than open :443 with no certificate,
+       which would make Blocky fail at runtime. config.sh warns when this happens. */}}
+{{- $tlsReady := and $httpsRequested .https.cert_file .https.key_file }}
+{{- if $tlsReady }}
 # TLS Certificate
 certFile: {{ .https.cert_file | quote }}
 keyFile: {{ .https.key_file | quote }}
@@ -387,12 +391,12 @@ keyFile: {{ .https.key_file | quote }}
 ports:
   http:
     - 4000 # Hardcoded since this is the internal Docker port
-{{- if $httpsEnabled }}
+{{- if $tlsReady }}
   https:
     - 443 # Hardcoded since this is the internal Docker HTTPS/DoH port
 {{- end }}
 
-{{- if .http3.enable }}
+{{- if and .http3.enable $tlsReady }}
 # DNS-over-HTTPS over HTTP/3
 http3:
   enable: true

--- a/docs/adr/0002-validation-and-failure-policy.md
+++ b/docs/adr/0002-validation-and-failure-policy.md
@@ -1,0 +1,14 @@
+# Where config validation lives, and how invalid combinations fail
+
+Home Assistant's add-on options schema validates only **per-field** (types, `match(REGEX)`, `list(enum)` — no conditional or cross-field rules). It cannot express "`cert_file` is required when `https.enable` is true". So **field-level** correctness lives in `config.yaml`'s schema (enums, regex, ranges), and **cross-field** correctness can only live in the Tempio template (`blocky.gtpl`) and the `cont-init.d` guards, with `blocky validate` as the final backstop.
+
+For inconsistent multi-field combinations we decide **per feature** using one test: **"Does Blocky still resolve DNS without this feature?"**
+
+- **No → core → fail-fast.** `config.sh` logs a clear error and aborts (same pattern as the query-log path check). Covers `upstreams`, `bootstrap`, and any case that yields fundamentally invalid YAML.
+- **Yes → side → degrade + warn.** The template/guard actively detects the broken combination, **omits that feature so the generated YAML stays valid**, and `bashio::log.warning` explains what was dropped. DNS keeps serving. Covers `https`/`http3`/DoH, `prometheus`, `redis`, `query_log`, `blocking`, `ecs`, `conditional`, `custom_dns`.
+
+**Considered & rejected:** (1) *Schema-first hard enforcement* of dependencies — impossible, HA schema has no cross-field validation. (2) *Pure fail-fast for everything* (today's de-facto behavior, since any invalid YAML makes `blocky validate` abort the whole add-on) — rejected because a single misconfigured side feature (e.g. HTTPS enabled without a cert) should not take down DNS for the whole network. (3) *Pure degrade* — rejected because silently resolving with no upstreams is worse than a loud failure.
+
+**Consequence:** Every new multi-field block must answer the DNS test and wire up the matching behavior. "Side" features are not free — degrade requires the template to emit valid YAML with the broken part removed *and* a guard that warns; relying on `blocky validate` alone gives fail-fast, not degrade.
+
+**Guards validate the rendered config, not a re-derivation of the options.** A guard in `cont-init.d` must read what it checks from the already-rendered `/etc/blocky/config.yml` (the real contract with Blocky), never re-compute defaults from `options.json` in parallel. Parallel derivation invites drift: the original query-log path check duplicated the template's default paths (`/config/query_logs`, `/config/querylog.db`) in `config.sh`, so changing one silently broke the other. Reading the effective `target:` straight from the rendered YAML makes drift impossible by construction — the coupling to the template's output format is narrow, visible, and fails loudly (empty path → validation trips) rather than silently.


### PR DESCRIPTION
## Why

Home Assistant's add-on options schema validates **per-field only** (types, `match()`, `list()` enums) — it cannot express cross-field rules like "`cert_file` is required when `https.enable` is true". So invalid *combinations* slip past schema validation and today all fail-fast via `blocky validate`, which is all-or-nothing: one misconfigured side feature takes down DNS for the whole network.

This PR establishes a per-feature failure policy (**ADR-0002**) and fixes the two combinations that actually misbehave. Found during a correctness/robustness review of the `config.yaml` ↔ `blocky.gtpl` ↔ `config.sh` pipeline.

## Policy (ADR-0002)

One test per feature: **"Does Blocky still resolve DNS without it?"**
- **No → core → fail-fast** (e.g. `upstreams`, `bootstrap`)
- **Yes → side → degrade + warn** (e.g. `https`/DoH, `prometheus`, `redis`, `query_log`, `blocking`)

## Fixes

**1. HTTPS/DoH without a certificate** (`blocky.gtpl`, `config.sh`)
The template emitted `ports: https: [443]` whenever https/http3 was enabled — even with empty `cert_file`/`key_file` — so Blocky opened `:443` with no certificate and crashed at runtime. HTTPS is a side feature, so we now degrade: a new `$tlsReady` gates the https port, `certFile`/`keyFile` **and** `http3` together, and `config.sh` warns when TLS was requested but cert/key aren't both set. DNS keeps serving.

**2. Query-log target path drift** (`config.sh`)
The default target path (`/config/query_logs`, `/config/querylog.db`) was duplicated in both `blocky.gtpl` and `config.sh` — a comment even admitted the coupling. The path guard could validate a *different* path than the one Blocky writes to. `config.sh` now reads the effective `target:` straight from the **rendered** config (single source of truth), and the duplicated defaults are gone. Drift is now impossible by construction.

**Not changed:** `fallbackUpstream` (schema `bool?`, Blocky-side boolean — current unquoted output is correct; quoting it would have been the bug). `start_verify` precedence (defensible legacy-upgrade path, #245).

## Docs

- `docs/adr/0002-validation-and-failure-policy.md` — the policy + the "guards validate the rendered config, never a re-derivation" principle
- `CONTEXT.md` — initial glossary (was empty): Standard/Custom Config Mode, Rendered config, Guard, Core/Side feature, Denylist/Allowlist

## Testing

Lint (`bash -n`, template delimiter balance) and the `sed` extraction were verified locally; `tempio`/`blocky`/`shellcheck` weren't available locally. Recommend in-container:

```
tempio -conf /data/options.json -template /usr/share/tempio/blocky.gtpl -out /tmp/test.yml && blocky validate --config /tmp/test.yml
```
once with `https.enable=true` and no cert (expect warning + no `:443`), once with a sqlite query log (path guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)