### PR TITLE
fix: warn on ignored single_name_order and skip empty customTTL

### DIFF
--- a/blocky/rootfs/etc/cont-init.d/config.sh
+++ b/blocky/rootfs/etc/cont-init.d/config.sh
@@ -95,6 +95,15 @@ if bashio::config.true 'https.enable' || bashio::config.true 'http3.enable'; the
     fi
 fi
 
+# client_lookup.single_name_order only has meaning together with an upstream
+# (it orders the rDNS lookup results). The template drops it when no upstream is
+# set (ADR-0002 degrade); warn so the operator knows their setting was ignored.
+# Count the array directly: has_value treats an empty list as "present".
+SINGLE_NAME_ORDER_COUNT=$(jq -r '(.client_lookup.single_name_order // []) | length' /data/options.json 2>/dev/null || echo 0)
+if [ "${SINGLE_NAME_ORDER_COUNT}" -gt 0 ] && ! bashio::config.has_value 'client_lookup.upstream'; then
+    bashio::log.warning "client_lookup.single_name_order is set but client_lookup.upstream is missing; single_name_order is ignored."
+fi
+
 # Prepare on-disk query log storage. CSV/csv-client write daily-rotating files
 # into a target DIRECTORY; sqlite writes a single database FILE whose parent
 # directory must exist. Both must stay under /config/ for persistence.

--- a/blocky/rootfs/usr/share/tempio/blocky.gtpl
+++ b/blocky/rootfs/usr/share/tempio/blocky.gtpl
@@ -77,7 +77,9 @@ fqdnOnly:
 {{- if or .custom_dns.mapping .custom_dns.rewrite }}
 # Custom DNS
 customDNS:
+{{- if .custom_dns.custom_ttl }}
   customTTL: {{ .custom_dns.custom_ttl | quote }}
+{{- end }}
   filterUnmappedTypes: {{ .custom_dns.filter_unmapped_types }}
 {{- if .custom_dns.rewrite }}
   rewrite:


### PR DESCRIPTION
Follow-up to #249. Two minor robustness items found during the same correctness review, consistent with the per-feature degrade policy from ADR-0002.

## Fixes

**1. `single_name_order` silently dropped** (`config.sh`)
`client_lookup.single_name_order` only has meaning together with an `upstream` (it orders the rDNS lookup results), so the template drops it when no upstream is set. Previously this happened with no feedback. `config.sh` now warns the operator that the setting was ignored. The array length is read via `jq` directly from `options.json` because bashio's `has_value` treats an empty list as "present" — checking it naively would warn on the default config.

**2. Empty `customTTL`** (`blocky.gtpl`)
`customDNS.customTTL` was emitted whenever a `mapping` or `rewrite` existed, so clearing the TTL field produced `customTTL: ""` — an empty duration Blocky's `validate` rejects (a cryptic fail-fast). It is now only emitted when set, like the other optional fields.

## Testing

`bash -n`, template delimiter balance, and the `jq` length logic verified locally (empty/missing list → 0 → no warning; populated list → warns). `tempio`/`blocky`/`shellcheck` not available locally; CI covers shellcheck, and the in-container render check from #249 applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)