### PR TITLE
docs: record add-on fixes in 5.0.0 changelog and correct HTTPS cert docs

### DIFF
--- a/blocky/CHANGELOG.md
+++ b/blocky/CHANGELOG.md
@@ -19,13 +19,21 @@ Bundles all changes since 4.1.1 (the previously documented 4.2.0 was never relea
 - On-disk block-list download cache: `blocking.download_cache` persists downloaded lists under `/data/cache/lists` for faster restarts and resilience during source outages
 - DNS-over-QUIC (DoQ) upstreams: `quic:` / `quic://` resolvers plus optional `upstreams.quic.max_idle_timeout` and `upstreams.quic.keep_alive_period` tuning
 - Schedule-based blocking: `blocking.schedules` and `blocking.list_schedules` to activate allowlist or denylist groups only on selected weekdays or time windows
-- HTTPS/DoH listener on internal port 443 (`https.enable`, optional `https.cert_file` / `https.key_file`; self-signed certificate generated when unset)
+- HTTPS/DoH listener on internal port 443 (`https.enable`). Requires both `https.cert_file` and `https.key_file`; when either is missing the listener is skipped and a warning is logged rather than starting Blocky with no certificate
 - DNS-over-HTTPS over HTTP/3 (DoH3) via `http3.enable` on internal port 443/udp
 - Optional add-on ports `443/tcp` and `443/udp` (disabled by default in Home Assistant's port settings)
 
 ### Deprecated
 
 - `upstreams.start_verify` is deprecated. Blocky folded the underlying `startVerifyUpstream` setting into the init strategy. The option is **still accepted** so existing configurations keep working unchanged, and `start_verify: true` is automatically mapped to `init_strategy: failOnError`. Switch to `init_strategy` at your convenience; `start_verify` will be removed in a future major release.
+
+### Fixed
+
+- The add-on now fails fast with a clear error when the rendered config has no default upstream group with a resolver — previously it would start and then silently fail to resolve DNS (Standard Mode only; custom configurations are left to Blocky's own validation)
+- Enabling HTTPS/DoH (`https.enable`) or DoH3 (`http3.enable`) without a certificate no longer opens port 443 with no cert and crashes Blocky — the listener is now skipped and a warning is logged when TLS is requested but no `cert_file`/`key_file` is set (DNS resolution is unaffected)
+- The query-log path guard now reads the effective `target:` straight from the rendered config instead of a separately-defined default, so it can no longer validate a different path than the one Blocky actually writes to
+- `custom_dns.custom_ttl` is now emitted only when set — clearing the field previously produced an empty `customTTL` that Blocky rejects
+- `client_lookup.single_name_order` now logs a warning when it is ignored (it only orders reverse-DNS lookups, so it has no effect unless a client-lookup upstream is configured)
 
 ### Added (Upstream Blocky)
 

--- a/blocky/DOCS.md
+++ b/blocky/DOCS.md
@@ -27,6 +27,8 @@ Configure external DNS resolvers that Blocky queries after checking blocks and c
 - **Verify Upstreams on Start** (`start_verify`): **deprecated** — kept for backward compatibility. When enabled it is mapped to `init_strategy: failOnError`. Prefer setting Init Strategy directly.
 - **QUIC Settings**: optional DoQ idle timeout and keep-alive tuning for `quic:` upstreams.
 
+A `default` group with at least one resolver is required. If you clear it, the add-on aborts at startup with a clear error instead of running unable to resolve DNS.
+
 If your WAN link is unreliable, consider `init_strategy: fast` to avoid startup stalls, or `init_strategy: failOnError` when you want startup to fail unless an upstream is reachable.
 
 > **Migration note:** Blocky folded "verify upstreams on start" into the init strategy, so the separate `start_verify` option is **deprecated**. It is still accepted — existing configurations keep working unchanged, and `start_verify: true` is automatically mapped to `init_strategy: failOnError`. No action is required; switch to `init_strategy` at your convenience. `start_verify` will be removed in a future major release.
@@ -205,7 +207,7 @@ The add-on can start Blocky's HTTPS listener on internal port `443`. This can se
 
 Map the add-on's `443/tcp` port for HTTPS/DoH clients and `443/udp` for DoH3 clients. Both are disabled by default in Home Assistant's add-on port settings.
 
-If no certificate is configured, Blocky generates a self-signed certificate. For real clients, mount trusted certificate files under `/ssl` and configure `https.cert_file` and `https.key_file`, for example `/ssl/fullchain.pem` and `/ssl/privkey.pem`.
+A certificate is **required**: configure both `https.cert_file` and `https.key_file` (for example `/ssl/fullchain.pem` and `/ssl/privkey.pem`, mounting trusted certificate files under `/ssl`). If either is missing, the add-on skips the HTTPS/DoH/DoH3 listener entirely and logs a warning rather than starting Blocky with no certificate — DNS resolution is unaffected.
 
 ### Client Lookup
 
@@ -463,7 +465,9 @@ Ingress is not enabled by default because Blocky provides an API rather than a d
 
 ### Standard mode (UI-driven)
 
-Schema migrations are handled by template/config updates shipped with the add-on. Upgrading the add-on updates generated config on restart.
+Schema migrations are handled by template/config updates shipped with the add-on. Upgrading the add-on regenerates the config on restart, so no manual action is required.
+
+Home Assistant does not auto-migrate add-on options: on an upgrade it keeps your saved value for every option still in the schema and drops the rest. The add-on works with this by **retaining deprecated options** in the schema and translating them to their current equivalent on every render (for example, `start_verify: true` is mapped to `init_strategy: failOnError`). Your existing settings therefore keep working across upgrades without edits. When an option is finally removed in a future major release, it is called out in the changelog's **Deprecated**/**Removed** sections — review those before a major upgrade.
 
 ### Custom config mode
 


### PR DESCRIPTION
## Why

The `[5.0.0]` changelog (still unreleased) only listed **upstream-Blocky** fixes — the add-on's own fixes merged since #247 were never recorded, and one HTTPS claim had gone stale after #249.

## Changelog (`blocky/CHANGELOG.md`)

New add-on **Fixed** section under `[5.0.0]`:

- Fail-fast with a clear error when the rendered config has no default upstream group with a resolver (#253)
- HTTPS/DoH/DoH3 without a certificate is now skipped + warned instead of opening :443 with no cert and crashing Blocky (#249)
- Query-log path guard reads the effective `target:` from the rendered config instead of a duplicated default (#249)
- `custom_dns.custom_ttl` emitted only when set — clearing it no longer produces an invalid empty `customTTL` (#250)
- `client_lookup.single_name_order` logs a warning when ignored (#250)

**Corrected stale claim:** the "Added" line said *"self-signed certificate generated when unset"* — since #249 the add-on requires both `cert_file` and `key_file` and otherwise skips the listener.

## Docs (`blocky/DOCS.md`)

- HTTPS section: a certificate (`cert_file` + `key_file`) is now **required**; otherwise the listener is skipped with a warning (DNS unaffected).
- Standard-mode migration: expanded to describe **passive migration** (deprecated keys retained in the schema and translated on render), matching ADR-0005.
- Upstream section: documented that a `default` group with a resolver is required (else fail-fast).

## Scope

Verified against the template (`$tlsReady` gating) before correcting the HTTPS docs. Deliberately excluded from this user-facing changelog: #251 (render harness) and #254 (deprecation contract check) — dev/CI tooling with no user-visible behavior, already covered by ADR-0003/0005 — and #252 (CI deps bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)