### PR TITLE
[codex] add connect ip version option

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,8 +7,8 @@ A containerized integration layer that translates Home Assistant add-on options 
 ### Configuration modes
 
 **Standard Mode**:
-The default. HA UI options are rendered through the Tempio template into the runtime config on every restart.
-_Avoid_: default mode, UI mode
+The default, curated HA-facing configuration surface: HA UI options are rendered through the Tempio template into the runtime config on every restart. It intentionally exposes only Blocky options that are understandable and broadly useful in Home Assistant; specialist Blocky settings belong in Custom Config Mode.
+_Avoid_: default mode, UI mode, full Blocky coverage
 
 **Custom Config Mode**:
 The operator supplies a complete Blocky YAML; template rendering is bypassed entirely and UI options are ignored. Generated once on first run, then preserved.

--- a/blocky/DOCS.md
+++ b/blocky/DOCS.md
@@ -33,6 +33,16 @@ If your WAN link is unreliable, consider `init_strategy: fast` to avoid startup 
 
 > **Migration note:** Blocky folded "verify upstreams on start" into the init strategy, so the separate `start_verify` option is **deprecated**. It is still accepted — existing configurations keep working unchanged, and `start_verify: true` is automatically mapped to `init_strategy: failOnError`. No action is required; switch to `init_strategy` at your convenience. `start_verify` will be removed in a future major release.
 
+### Outgoing IP Version
+
+Controls which IP protocol Blocky uses for outgoing network connections, including upstream DNS resolvers and downloaded blocklists.
+
+- `dual` (default): allow both IPv4 and IPv6
+- `v4`: force IPv4 outgoing connections
+- `v6`: force IPv6 outgoing connections
+
+This does not filter client DNS query types or suppress AAAA answers. To block specific DNS record types, use Filtering.
+
 ### Bootstrap DNS
 
 Required when upstream DNS uses hostnames (e.g., `tcp-tls:dns.google`). Bootstrap resolvers are simple IP-based DNS servers that resolve those hostnames, breaking the circular dependency.

--- a/blocky/config.yaml
+++ b/blocky/config.yaml
@@ -40,6 +40,7 @@ options:
     quic:
       max_idle_timeout: ""
       keep_alive_period: ""
+  connect_ip_version: dual
   bootstrap:
     dns:
       - upstream: 1.1.1.1
@@ -150,6 +151,7 @@ schema:
     quic:
       max_idle_timeout: str?
       keep_alive_period: str?
+  connect_ip_version: list(dual|v4|v6)?
   bootstrap:
     dns:
       - upstream: str

--- a/blocky/rootfs/usr/share/tempio/blocky.gtpl
+++ b/blocky/rootfs/usr/share/tempio/blocky.gtpl
@@ -44,6 +44,10 @@ upstreams:
   userAgent: {{ .upstreams.user_agent | quote }}
 {{- end }}
 
+{{- if .connect_ip_version }}
+# Outgoing IP Version
+connectIPVersion: {{ .connect_ip_version | quote }}
+{{- end }}
 
 {{- if .bootstrap.dns }}
 # Bootstrap DNS

--- a/blocky/translations/en.yaml
+++ b/blocky/translations/en.yaml
@@ -42,6 +42,11 @@ configuration:
         name: User Agent
         description: >-
           Custom User-Agent header for DNS-over-HTTPS (DoH) requests. Only applies to HTTPS upstream resolvers (https://...). Some DNS providers require or prefer specific User-Agent strings for identification, rate limiting, or analytics purposes. Leave empty to use Blocky's default User-Agent. Has no effect on DNS-over-TLS (tcp-tls:...), DNS-over-QUIC (quic:...), or plain DNS resolvers. Example: "MyNetwork-DNS/1.0" or "Blocky-HomeAssistant".
+
+  connect_ip_version:
+    name: Outgoing IP Version
+    description: >-
+      Controls which IP protocol Blocky uses for outgoing network connections, including upstream DNS resolvers and downloaded blocklists. Use dual for normal dual-stack behavior, v4 to force IPv4, or v6 to force IPv6. This does not filter client DNS query types or suppress AAAA answers; use Filtering if you need to block specific DNS record types. Default: dual.
   
   bootstrap:
     name: Bootstrap DNS

--- a/docs/adr/0006-standard-mode-is-curated.md
+++ b/docs/adr/0006-standard-mode-is-curated.md
@@ -1,0 +1,9 @@
+# Standard Mode is a curated HA-facing surface
+
+Standard Mode is not a goal to expose every Blocky setting in the Home Assistant UI. It is a curated configuration surface for options that are understandable to typical HA home-network operators, solve a common operational problem, and can be rendered safely into Blocky's YAML without making the UI feel like a second copy of the upstream configuration reference.
+
+Custom Config Mode is the escape hatch for specialist Blocky settings. When an issue asks to expose another upstream option, the default answer is not "yes because Blocky supports it"; the option must earn a place in Standard Mode by being broadly useful in the HA context and safe to operate without deep DNS-specific knowledge.
+
+**Considered & rejected:** Treat Standard Mode as full Blocky coverage. Rejected because it makes the HA UI harder to use, increases schema/template/translation/test surface for niche settings, and blurs the already-clear boundary that Custom Config Mode owns complete Blocky YAML.
+
+**Consequence:** Feature triage should classify new Blocky options as either Standard Mode candidates or Custom Config Mode-only settings. Simple, common home-network controls such as upstream IP protocol selection, ECS subnet precision, or blocklist refresh cadence can belong in Standard Mode; specialist or pipeline-oriented settings such as structured log format or special-use domain handling stay in Custom Config Mode unless a concrete HA-centered use case proves otherwise.

--- a/scripts/render-test/fixtures/caching-large-items/expected.yml
+++ b/scripts/render-test/fixtures/caching-large-items/expected.yml
@@ -16,6 +16,8 @@ upstreams:
     strategy: "blocking"
   strategy: "parallel_best"
   timeout: "2s"
+# Outgoing IP Version
+connectIPVersion: "dual"
 # Bootstrap DNS
 bootstrapDns:
   - upstream: "1.1.1.1"

--- a/scripts/render-test/fixtures/conditional-mapping/expected.yml
+++ b/scripts/render-test/fixtures/conditional-mapping/expected.yml
@@ -16,6 +16,8 @@ upstreams:
     strategy: "blocking"
   strategy: "parallel_best"
   timeout: "2s"
+# Outgoing IP Version
+connectIPVersion: "dual"
 # Bootstrap DNS
 bootstrapDns:
   - upstream: "1.1.1.1"

--- a/scripts/render-test/fixtures/connect-ip-version-v4/expected.yml
+++ b/scripts/render-test/fixtures/connect-ip-version-v4/expected.yml
@@ -17,17 +17,11 @@ upstreams:
   strategy: "parallel_best"
   timeout: "2s"
 # Outgoing IP Version
-connectIPVersion: "dual"
+connectIPVersion: "v4"
 # Bootstrap DNS
 bootstrapDns:
   - upstream: "1.1.1.1"
   - upstream: "8.8.8.8"
-# Client Name Lookup
-clientLookup:
-  upstream: "192.168.178.1"
-  singleNameOrder:
-    - 2
-    - 1
 # Blocking & Allowlists
 blocking:
   denylists:

--- a/scripts/render-test/fixtures/connect-ip-version-v4/override.json
+++ b/scripts/render-test/fixtures/connect-ip-version-v4/override.json
@@ -1,0 +1,3 @@
+{
+  "connect_ip_version": "v4"
+}

--- a/scripts/render-test/fixtures/custom-dns-empty-ttl/expected.yml
+++ b/scripts/render-test/fixtures/custom-dns-empty-ttl/expected.yml
@@ -16,6 +16,8 @@ upstreams:
     strategy: "blocking"
   strategy: "parallel_best"
   timeout: "2s"
+# Outgoing IP Version
+connectIPVersion: "dual"
 # Bootstrap DNS
 bootstrapDns:
   - upstream: "1.1.1.1"

--- a/scripts/render-test/fixtures/defaults/expected.yml
+++ b/scripts/render-test/fixtures/defaults/expected.yml
@@ -16,6 +16,8 @@ upstreams:
     strategy: "blocking"
   strategy: "parallel_best"
   timeout: "2s"
+# Outgoing IP Version
+connectIPVersion: "dual"
 # Bootstrap DNS
 bootstrapDns:
   - upstream: "1.1.1.1"

--- a/scripts/render-test/fixtures/querylog-csv-default/expected.yml
+++ b/scripts/render-test/fixtures/querylog-csv-default/expected.yml
@@ -16,6 +16,8 @@ upstreams:
     strategy: "blocking"
   strategy: "parallel_best"
   timeout: "2s"
+# Outgoing IP Version
+connectIPVersion: "dual"
 # Bootstrap DNS
 bootstrapDns:
   - upstream: "1.1.1.1"

--- a/scripts/render-test/fixtures/querylog-mysql/expected.yml
+++ b/scripts/render-test/fixtures/querylog-mysql/expected.yml
@@ -16,6 +16,8 @@ upstreams:
     strategy: "blocking"
   strategy: "parallel_best"
   timeout: "2s"
+# Outgoing IP Version
+connectIPVersion: "dual"
 # Bootstrap DNS
 bootstrapDns:
   - upstream: "1.1.1.1"

--- a/scripts/render-test/fixtures/querylog-postgres/expected.yml
+++ b/scripts/render-test/fixtures/querylog-postgres/expected.yml
@@ -16,6 +16,8 @@ upstreams:
     strategy: "blocking"
   strategy: "parallel_best"
   timeout: "2s"
+# Outgoing IP Version
+connectIPVersion: "dual"
 # Bootstrap DNS
 bootstrapDns:
   - upstream: "1.1.1.1"

--- a/scripts/render-test/fixtures/querylog-sqlite-default/expected.yml
+++ b/scripts/render-test/fixtures/querylog-sqlite-default/expected.yml
@@ -16,6 +16,8 @@ upstreams:
     strategy: "blocking"
   strategy: "parallel_best"
   timeout: "2s"
+# Outgoing IP Version
+connectIPVersion: "dual"
 # Bootstrap DNS
 bootstrapDns:
   - upstream: "1.1.1.1"

--- a/scripts/render-test/fixtures/single-name-order-no-upstream/expected.yml
+++ b/scripts/render-test/fixtures/single-name-order-no-upstream/expected.yml
@@ -16,6 +16,8 @@ upstreams:
     strategy: "blocking"
   strategy: "parallel_best"
   timeout: "2s"
+# Outgoing IP Version
+connectIPVersion: "dual"
 # Bootstrap DNS
 bootstrapDns:
   - upstream: "1.1.1.1"

--- a/scripts/render-test/fixtures/start-verify-legacy/expected.yml
+++ b/scripts/render-test/fixtures/start-verify-legacy/expected.yml
@@ -16,6 +16,8 @@ upstreams:
     strategy: "failOnError"
   strategy: "parallel_best"
   timeout: "2s"
+# Outgoing IP Version
+connectIPVersion: "dual"
 # Bootstrap DNS
 bootstrapDns:
   - upstream: "1.1.1.1"

--- a/scripts/render-test/fixtures/tls-no-cert/expected.yml
+++ b/scripts/render-test/fixtures/tls-no-cert/expected.yml
@@ -16,6 +16,8 @@ upstreams:
     strategy: "blocking"
   strategy: "parallel_best"
   timeout: "2s"
+# Outgoing IP Version
+connectIPVersion: "dual"
 # Bootstrap DNS
 bootstrapDns:
   - upstream: "1.1.1.1"

--- a/scripts/render-test/fixtures/tls-ready/expected.yml
+++ b/scripts/render-test/fixtures/tls-ready/expected.yml
@@ -16,6 +16,8 @@ upstreams:
     strategy: "blocking"
   strategy: "parallel_best"
   timeout: "2s"
+# Outgoing IP Version
+connectIPVersion: "dual"
 # Bootstrap DNS
 bootstrapDns:
   - upstream: "1.1.1.1"

--- a/scripts/render-test/fixtures/upstreams-empty/expected.yml
+++ b/scripts/render-test/fixtures/upstreams-empty/expected.yml
@@ -12,6 +12,8 @@ upstreams:
     strategy: "blocking"
   strategy: "parallel_best"
   timeout: "2s"
+# Outgoing IP Version
+connectIPVersion: "dual"
 # Bootstrap DNS
 bootstrapDns:
   - upstream: "1.1.1.1"


### PR DESCRIPTION
## Summary

Adds connect_ip_version to Standard Mode so Home Assistant users can choose whether Blocky uses dual-stack, IPv4-only, or IPv6-only outgoing network connections.

This also records the Standard Mode boundary decided during triage: Standard Mode is a curated HA-facing configuration surface, while specialist Blocky options belong in Custom Config Mode.

Closes #189.

## Changes

- Add connect_ip_version: dual to the add-on options schema with dual, v4, and v6 choices.
- Render the setting as Blocky connectIPVersion.
- Add HA translation text and add-on docs that clarify this affects outgoing connections, not DNS query type filtering.
- Add a focused connect-ip-version-v4 render fixture and refresh goldens for the new default-rendered field.
- Document the curated Standard Mode decision in CONTEXT.md and ADR-0006.

## Validation

- node scripts/check-config-contract.mjs
- Docker/Linux render harness: node scripts/render-test/run.mjs