### PR TITLE
refactor: move query-log inspection behind the guards seam

### DIFF
--- a/blocky/rootfs/etc/cont-init.d/config.sh
+++ b/blocky/rootfs/etc/cont-init.d/config.sh
@@ -98,6 +98,45 @@ if ! bashio::config.true 'custom_config'; then
         bashio::log.fatal "Blocky cannot resolve DNS without it. Set upstreams → groups → a 'default' group with at least one resolver in the add-on options."
         exit 1
     fi
+
+    # Prepare on-disk query log storage. CSV/csv-client write daily-rotating
+    # files into a target DIRECTORY; sqlite writes a single database FILE whose
+    # parent directory must exist. Both must stay under /config/ for persistence.
+    #
+    # The guards read the effective target straight from the RENDERED config (the
+    # single source of truth, see ADR-0002) and encapsulate the type/path parsing,
+    # so this block holds only filesystem side effects. The parse is format-coupled
+    # and runs in Standard Mode only (ADR-0004): a hand-written custom config may
+    # use a YAML shape the parser was never built for, and a fail-fast guard must
+    # never abort a correct config — Blocky's own logging surfaces errors there.
+    QUERY_LOG_TARGET="$(query_log_target "${CONFIG_PATH}/config.yml")"
+    if [ -n "${QUERY_LOG_TARGET}" ]; then
+        if ! query_log_target_is_safe "${QUERY_LOG_TARGET}"; then
+            bashio::log.fatal "Query log target must be a path under /config/ with no '..': ${QUERY_LOG_TARGET}"
+            exit 1
+        fi
+
+        QUERY_LOG_DIR="$(query_log_dir "${CONFIG_PATH}/config.yml")"
+        bashio::log.info "Creating query log directory: ${QUERY_LOG_DIR}"
+        if ! mkdir -p "${QUERY_LOG_DIR}"; then
+            bashio::log.fatal "Failed to create query log directory: ${QUERY_LOG_DIR}"
+            exit 1
+        fi
+
+        # Verify canonical path stays within /config/ (catches symlink attacks).
+        # Reuse the same containment rule as the target check so the /config
+        # policy lives in exactly one place (realpath output carries no '..').
+        CANONICAL_PATH=$(realpath "${QUERY_LOG_DIR}")
+        if ! query_log_target_is_safe "${CANONICAL_PATH}"; then
+            bashio::log.fatal "Query log directory resolves outside /config/: ${CANONICAL_PATH}"
+            exit 1
+        fi
+
+        if [ ! -w "${QUERY_LOG_DIR}" ]; then
+            bashio::log.fatal "Query log directory is not writable: ${QUERY_LOG_DIR}"
+            exit 1
+        fi
+    fi
 fi
 
 # HTTPS/DoH is a side feature (ADR-0002): when enabled without a certificate the
@@ -117,63 +156,6 @@ fi
 SINGLE_NAME_ORDER_COUNT=$(jq -r '(.client_lookup.single_name_order // []) | length' /data/options.json 2>/dev/null || echo 0)
 if [ "${SINGLE_NAME_ORDER_COUNT}" -gt 0 ] && ! bashio::config.has_value 'client_lookup.upstream'; then
     bashio::log.warning "client_lookup.single_name_order is set but client_lookup.upstream is missing; single_name_order is ignored."
-fi
-
-# Prepare on-disk query log storage. CSV/csv-client write daily-rotating files
-# into a target DIRECTORY; sqlite writes a single database FILE whose parent
-# directory must exist. Both must stay under /config/ for persistence.
-#
-# Read the effective target from the RENDERED config (the single source of
-# truth, see ADR-0002). We never re-derive the default path here: that would
-# duplicate the template's fallback and silently drift from the path Blocky
-# actually writes to. The coupling is narrow (one machine-generated line) and
-# fails loudly (empty path slips through to the containment check below).
-QUERY_LOG_TYPE=$(bashio::config 'query_log.type')
-QUERY_LOG_PATH=""
-
-case "${QUERY_LOG_TYPE}" in
-    csv | csv-client | sqlite)
-        QUERY_LOG_PATH=$(sed -n 's/^[[:space:]]*target:[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' \
-            "${CONFIG_PATH}/config.yml" | head -n1)
-        ;;
-esac
-
-if [ -n "${QUERY_LOG_PATH}" ]; then
-    # Validate the full target path (the value Blocky writes to) to prevent
-    # directory traversal and keep query logs under /config/.
-    if [[ "${QUERY_LOG_PATH}" == *".."* ]]; then
-        bashio::log.fatal "Query log target contains '..': ${QUERY_LOG_PATH}"
-        bashio::log.fatal "Path traversal is not allowed for query logs."
-        exit 1
-    elif [[ "${QUERY_LOG_PATH}" != /config && "${QUERY_LOG_PATH}" != /config/* ]]; then
-        bashio::log.fatal "Query log target must be under /config/: ${QUERY_LOG_PATH}"
-        exit 1
-    fi
-
-    # sqlite target is a file -> create its parent dir; csv target is the dir itself
-    if [[ "${QUERY_LOG_TYPE}" == "sqlite" ]]; then
-        QUERY_LOG_DIR=$(dirname "${QUERY_LOG_PATH}")
-    else
-        QUERY_LOG_DIR="${QUERY_LOG_PATH}"
-    fi
-
-    bashio::log.info "Creating query log directory: ${QUERY_LOG_DIR}"
-    if ! mkdir -p "${QUERY_LOG_DIR}"; then
-        bashio::log.fatal "Failed to create query log directory: ${QUERY_LOG_DIR}"
-        exit 1
-    fi
-
-    # Verify canonical path stays within /config/ (catches symlink attacks)
-    CANONICAL_PATH=$(realpath "${QUERY_LOG_DIR}")
-    if [[ "${CANONICAL_PATH}" != /config && "${CANONICAL_PATH}" != /config/* ]]; then
-        bashio::log.fatal "Query log directory resolves outside /config/: ${CANONICAL_PATH}"
-        exit 1
-    fi
-
-    if [ ! -w "${QUERY_LOG_DIR}" ]; then
-        bashio::log.fatal "Query log directory is not writable: ${QUERY_LOG_DIR}"
-        exit 1
-    fi
 fi
 
 # Create the on-disk block list download cache directory when enabled.

--- a/blocky/rootfs/usr/lib/blocky/guards.sh
+++ b/blocky/rootfs/usr/lib/blocky/guards.sh
@@ -8,8 +8,8 @@
 # the rendered config) and ADR-0004 (format-coupled guards are Standard-Mode-only).
 #
 # Each function is pure: it takes the config path as $1, reads nothing else, and
-# communicates via exit status — so it can be tested outside the container
-# (scripts/test-guards.sh asserts it against the render-test goldens).
+# communicates via exit status or stdout — so it can be tested outside the
+# container (scripts/test-guards.sh asserts them against the render-test goldens).
 # ==============================================================================
 
 # upstreams is a CORE feature: Blocky needs a "default" group with at least one
@@ -25,4 +25,66 @@ upstreams_default_has_resolver() {
         in_def && /^(  [^ ]|    [^ ])/      { in_def = 0 }          # default ended without a resolver
         END                                  { exit(found ? 0 : 1) }
     ' "$1"
+}
+
+# Read a single scalar field from the queryLog block of the rendered config.
+# Scopes to the "queryLog:" block (header at column 0) and prints the unquoted
+# value of "  <key>:" within it; prints nothing if the block or key is absent.
+# Internal helper, single-sourced between query_log_target and query_log_dir.
+_query_log_field() {
+    awk -v key="$2" '
+        BEGIN                        { pat = "^  " key ":[[:space:]]*" }
+        /^queryLog:/                 { in_q = 1; next }
+        in_q && /^[^[:space:]]/      { in_q = 0 }          # left the queryLog block
+        in_q && $0 ~ pat {
+            val = $0
+            sub(pat, "", val)                              # strip "  key:   "
+            sub(/^"/, "", val); sub(/"[[:space:]]*$/, "", val)  # strip surrounding quotes
+            print val
+            exit
+        }
+    ' "$1"
+}
+
+# query_log.type is csv/csv-client/sqlite -> "target:" is a filesystem PATH that
+# config.sh must create on disk. For mysql/postgresql/timescale "target:" is a
+# DSN connection string (NOT a path), and console/none/"" have no target at all.
+# This recognises the three path-bearing types by allowlist (so a future Blocky
+# db-type can never be mistaken for a path) and prints the target only for them;
+# prints nothing otherwise. The type is read from the rendered config, not from
+# options.json, so config.sh keeps no re-derivation of it (ADR-0002).
+query_log_target() {
+    case "$(_query_log_field "$1" type)" in
+        csv | csv-client | sqlite) _query_log_field "$1" target ;;
+    esac
+}
+
+# The directory config.sh must ensure exists for the query log. A sqlite target
+# is a FILE, so its parent directory is created; a csv/csv-client target IS the
+# directory. Prints nothing when there is no path-bearing target. Encapsulates
+# the file-vs-directory knowledge so config.sh never needs the type.
+query_log_dir() {
+    local target
+    case "$(_query_log_field "$1" type)" in
+        sqlite)
+            target="$(_query_log_field "$1" target)"
+            [ -n "${target}" ] && dirname "${target}"
+            ;;
+        csv | csv-client)
+            _query_log_field "$1" target
+            ;;
+    esac
+}
+
+# Pure string check on a query log target: succeeds (0) when the path is /config
+# or sits under /config/ and contains no ".." traversal; fails (1) otherwise.
+# The caller (config.sh) owns the fatal message. Takes the target string as $1.
+query_log_target_is_safe() {
+    case "$1" in
+        *..*) return 1 ;;
+    esac
+    case "$1" in
+        /config | /config/*) return 0 ;;
+        *) return 1 ;;
+    esac
 }

--- a/scripts/test-guards.sh
+++ b/scripts/test-guards.sh
@@ -71,6 +71,74 @@ else
     pass "no-default-group: rejected"
 fi
 
+# ---- query_log_target / query_log_dir / query_log_target_is_safe ------------
+
+# Every committed golden that yields a path-bearing target must produce one the
+# safety check accepts (goldens are all valid), and the two path-type defaults
+# must extract to exactly the expected target/dir. db/console/none yield nothing.
+for golden in "${FIXTURES}"/*/expected.yml; do
+    name="$(basename "$(dirname "${golden}")")"
+    target="$(query_log_target "${golden}")"
+
+    if [ -n "${target}" ]; then
+        if query_log_target_is_safe "${target}"; then
+            pass "${name}: query_log_target safe (${target})"
+        else
+            bad "${name}: emitted target rejected by is_safe (${target})"
+        fi
+    fi
+
+    # Exact-value contract for the path-type default fixtures. (run.mjs pins the
+    # rendered target line byte-for-byte; here we pin that the function extracts it.)
+    case "${name}" in
+        querylog-csv-default) exp_target="/config/query_logs"; exp_dir="/config/query_logs" ;;
+        querylog-sqlite-default) exp_target="/config/querylog.db"; exp_dir="/config" ;;
+        *) exp_target=""; exp_dir="" ;;
+    esac
+    if [ -n "${exp_target}" ]; then
+        if [ "${target}" = "${exp_target}" ]; then
+            pass "${name}: target == ${exp_target}"
+        else
+            bad "${name}: target '${target}' != '${exp_target}'"
+        fi
+        dir="$(query_log_dir "${golden}")"
+        if [ "${dir}" = "${exp_dir}" ]; then
+            pass "${name}: dir == ${exp_dir}"
+        else
+            bad "${name}: dir '${dir}' != '${exp_dir}'"
+        fi
+    fi
+done
+
+# Anti-DSN: db-type goldens carry a DSN in "target:", never a path. The function
+# must emit NOTHING for them — the bug-prone case the allowlist exists to prevent.
+for name in querylog-mysql querylog-postgres; do
+    golden="${FIXTURES}/${name}/expected.yml"
+    [ -f "${golden}" ] || continue
+    target="$(query_log_target "${golden}")"
+    if [ -z "${target}" ]; then
+        pass "${name}: db-type emits no path"
+    else
+        bad "${name}: db-type leaked a target (${target})"
+    fi
+done
+
+# Synthetic safety cases not represented by a golden.
+for safe in "/config" "/config/query_logs" "/config/querylog.db"; do
+    if query_log_target_is_safe "${safe}"; then
+        pass "is_safe accepts ${safe}"
+    else
+        bad "is_safe should accept ${safe}"
+    fi
+done
+for unsafe in "/config/../secrets" "/etc/passwd" "../x" "/configfoo"; do
+    if query_log_target_is_safe "${unsafe}"; then
+        bad "is_safe should reject ${unsafe}"
+    else
+        pass "is_safe rejects ${unsafe}"
+    fi
+done
+
 if [ "${fail}" -eq 0 ]; then
     echo "All guard checks passed."
 else


### PR DESCRIPTION
## What

Extracts the query-log path parsing that lived inline in `config.sh` into pure, single-sourced functions in `usr/lib/blocky/guards.sh`, alongside the existing upstreams guard. `config.sh` now holds only filesystem side effects.

This executes ADR-0004's stated design — *"format-coupled detection lives in `guards.sh` as pure functions, single-sourced between the runtime guard and its test"* — for the query-log guard, which previously remained inline and untested.

## New guard helpers

`config path in → value/status out`, tested by `scripts/test-guards.sh`:

- **`query_log_target`** — block-scoped `awk` + path-type **allowlist** (`csv`/`csv-client`/`sqlite`). Reads `type:` from the **rendered** config, so `config.sh` no longer re-derives `query_log.type` from `options.json` (tightens ADR-0002). db-type DSNs and `console`/`none` yield nothing — never mistaken for a path.
- **`query_log_dir`** — encapsulates file-vs-directory knowledge (`dirname` for sqlite, the target itself for csv) so `config.sh` needs no type knowledge.
- **`query_log_target_is_safe`** — pure `..`/`/config` containment check; the canonical-path check now reuses it, so the containment policy lives in one place.

## ⚠️ Behavior change

The query-log block (format-coupled parse + the **aborting** safety check) now runs in **Standard Mode only**, like the upstreams guard. Per ADR-0004, a format-coupled guard must never run against a hand-written custom config, where it could false-positive and abort a perfectly valid setup. Previously this block ran in both modes — a latent ADR-0004 violation this fixes.

## Testing

- `scripts/test-guards.sh` — 32 checks: every golden's emitted path accepted by `is_safe`; the two path-type defaults extract to exactly `/config/query_logs` and `/config/querylog.db`; the mysql/postgres goldens emit nothing (anti-DSN); synthetic traversal/containment cases.
- shellcheck clean · contract check pass · render harness 15/15 (Linux container).

## Review

High-effort workflow review (29 agents). The two CONFIRMED correctness findings (`*..*` over-rejection, outer-quote stripping) are both **identical to the pre-refactor behavior** — preserved, not introduced. One clean dedup was applied (canonical-path check reuses `query_log_target_is_safe`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)