### PR TITLE
refactor: collapse the render → validate ritual in config.sh

### DIFF
--- a/blocky/rootfs/etc/cont-init.d/config.sh
+++ b/blocky/rootfs/etc/cont-init.d/config.sh
@@ -19,6 +19,42 @@ if ! mkdir -p "${ADDON_CONFIG_PATH}"; then
     exit 1
 fi
 
+# render_config <out>: render the HA options through the Tempio template into
+# <out>, then prove the result is a non-empty, valid Blocky config. On ANY
+# failure it removes the partial/invalid render and returns non-zero; the caller
+# only needs `render_config <out> || exit 1`. Both configuration modes call this,
+# so the fatal wording is neutral — the info log each branch emits beforehand
+# tells the operator which mode they are in.
+#
+# Always removing the failed render matters for Custom Config Mode: a persisted
+# invalid config.yml would be mistaken for the operator's own config on the next
+# boot. It is harmless for Standard Mode, which regenerates every restart.
+render_config() {
+    local out="$1"
+    if ! tempio \
+        -conf /data/options.json \
+        -template /usr/share/tempio/blocky.gtpl \
+        -out "${out}"; then
+        bashio::log.fatal "Failed to generate configuration with tempio"
+        rm -f "${out}"
+        return 1
+    fi
+
+    if [ ! -f "${out}" ] || [ ! -s "${out}" ]; then
+        bashio::log.fatal "Configuration file was not created or is empty"
+        rm -f "${out}"
+        return 1
+    fi
+
+    if ! blocky validate --config "${out}"; then
+        bashio::log.fatal "Generated configuration is invalid"
+        rm -f "${out}"
+        return 1
+    fi
+
+    return 0
+}
+
 # Check if custom configuration is enabled
 if bashio::config.true 'custom_config'; then
     if [ -f "${ADDON_CONFIG_PATH}/config.yml" ]; then
@@ -27,27 +63,21 @@ if bashio::config.true 'custom_config'; then
         bashio::log.warning "UI options are IGNORED"
         bashio::log.info "Edit config.yml in this add-on's Home Assistant /addon_configs/... folder to modify your configuration"
         bashio::log.info "Inside the add-on container, this file is /config/config.yml"
+
+        # Validate the operator's own config so an invalid one fails fast with a
+        # clear error here instead of crash-looping Blocky at startup. This is
+        # Blocky's native validator, not a format-coupled text-parsing guard, so
+        # it is safe against a hand-written config (ADR-0004 governs the awk
+        # guards, not this). Never remove the file on failure — it belongs to the
+        # operator (unlike a render_config output, which we generated).
+        if ! blocky validate --config "${ADDON_CONFIG_PATH}/config.yml"; then
+            bashio::log.fatal "Existing custom config.yml is invalid. Fix it in this add-on's Home Assistant /addon_configs/... folder."
+            exit 1
+        fi
     else
         # Generate initial config for first run
         bashio::log.info "Custom config enabled: Generating initial configuration..."
-        if ! tempio \
-            -conf /data/options.json \
-            -template /usr/share/tempio/blocky.gtpl \
-            -out "${ADDON_CONFIG_PATH}/config.yml"; then
-            bashio::log.fatal "Failed to generate initial configuration with tempio"
-            exit 1
-        fi
-
-        if [ ! -f "${ADDON_CONFIG_PATH}/config.yml" ] || [ ! -s "${ADDON_CONFIG_PATH}/config.yml" ]; then
-            bashio::log.fatal "Configuration file was not created or is empty"
-            exit 1
-        fi
-
-        if ! blocky validate --config "${ADDON_CONFIG_PATH}/config.yml"; then
-            bashio::log.fatal "Generated initial configuration is invalid"
-            rm -f "${ADDON_CONFIG_PATH}/config.yml"
-            exit 1
-        fi
+        render_config "${ADDON_CONFIG_PATH}/config.yml" || exit 1
 
         bashio::log.info "Initial config created. You can now customize config.yml in this add-on's Home Assistant /addon_configs/... folder"
         bashio::log.info "Inside the add-on container, this file is /config/config.yml"
@@ -55,23 +85,7 @@ if bashio::config.true 'custom_config'; then
 else
     # Standard mode: always regenerate configuration from addon options
     bashio::log.info "Generating configuration from addon options..."
-    if ! tempio \
-        -conf /data/options.json \
-        -template /usr/share/tempio/blocky.gtpl \
-        -out "${ADDON_CONFIG_PATH}/config.yml"; then
-        bashio::log.fatal "Failed to generate configuration with tempio"
-        exit 1
-    fi
-
-    if [ ! -f "${ADDON_CONFIG_PATH}/config.yml" ] || [ ! -s "${ADDON_CONFIG_PATH}/config.yml" ]; then
-        bashio::log.fatal "Configuration file was not created or is empty"
-        exit 1
-    fi
-
-    if ! blocky validate --config "${ADDON_CONFIG_PATH}/config.yml"; then
-        bashio::log.fatal "Generated configuration is invalid"
-        exit 1
-    fi
+    render_config "${ADDON_CONFIG_PATH}/config.yml" || exit 1
 fi
 
 # Copy the generated config to the runtime location

--- a/blocky/rootfs/etc/services.d/blocky/run
+++ b/blocky/rootfs/etc/services.d/blocky/run
@@ -27,12 +27,15 @@ if [ ! -s "${CONFIG_FILE}" ]; then
     exit 1
 fi
 
-# Validate configuration against Blocky's schema
-bashio::log.info "Validating Blocky configuration..."
-if ! blocky validate --config "${CONFIG_FILE}"; then
-    bashio::log.fatal "Configuration validation failed: ${CONFIG_FILE}"
-    exit 1
-fi
+# No `blocky validate` here on purpose: cont-init.d/config.sh validates the
+# config in every mode before copying it into place — render_config validates a
+# freshly rendered config (standard mode and custom-config first run), and the
+# existing-custom-config branch validates the operator's file directly. Nothing
+# mutates /etc/blocky/config.yml between init and service start (or across s6
+# restarts, which re-run this script but not config.sh), so re-validating here
+# would re-prove an immutable, already-proven file on every restart. The cheap
+# existence/readable/non-empty checks above stay — they catch a missing or
+# truncated copy near-free.
 
 bashio::log.info "Pre-flight checks passed"
 bashio::log.info "Starting Blocky..."


### PR DESCRIPTION
## What

Collapses the duplicated render → validate ritual in `config.sh` into a single local `render_config <out>` function, and removes the now-redundant `blocky validate` from `services.d/blocky/run`.

This is the second deepening from the architecture review (after #257). The same four-step "render and prove the config" sequence was copied across both `config.sh` branches and partly again in `run`; the fatal messages had drifted apart.

## Changes

- **`render_config <out>`** (new local function in `config.sh`): renders via `tempio`, proves the result is non-empty and valid, and on **any** failure removes the partial/invalid render and returns non-zero. Each caller is just `render_config <out> || exit 1`. Always-rm-on-failure is mandatory for Custom Config Mode (a persisted invalid render would be mistaken for the operator's own config next boot) and harmless for Standard Mode.
- **Existing-custom-config path now validated**: that branch previously copied the operator's hand-written `config.yml` unvalidated and relied solely on `run`'s validate. It now validates in `config.sh` (Blocky's native validator — not a format-coupled guard, so safe against a hand-written config per ADR-0004), **never deleting the operator's file**, so an invalid custom config fails fast with a clear error instead of crash-looping Blocky.
- **`run` validate dropped**: `config.sh` validates the config in every mode before copying it into place, and nothing mutates `/etc/blocky/config.yml` between init and service start or across s6 restarts. `run` keeps its cheap existence/readable/non-empty pre-flight.

## Verification

- shellcheck (CI parity) — clean
- `scripts/test-guards.sh` — 32 checks pass
- contract checker — pass
- render harness — 15/15 fixtures

A high-effort code review caught the missing validation on the existing-custom-config path; the fix above is included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)