### PR TITLE
docs: add Blocky bump-review policy and changelog ADRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ The template handles groups (upstreams, blocklists, clients), strategy enums, co
 - **Versioning**: `scripts/update-addon-version.mjs` is called by semantic-release to stamp the version into `blocky/config.yaml`
 - **Commits**: conventional commits (`feat:` → minor, `fix:` → patch, `feat(deps):` for Blocky updates, `fix(deps):` for Tempio)
 - **Dev Deploy** (`.github/workflows/deploy-dev.yml`): push to main touching `blocky/**` → syncs `blocky-dev/` with patched config → commits back to main with `[skip ci]`
-- **Renovate** (`renovate.json`): auto-updates Blocky, Tempio, base images, and semantic-release packages. Patches auto-merge; Blocky bumps require manual review.
+- **Renovate** (`renovate.json`): auto-updates Blocky, Tempio, base images, and semantic-release packages. Patches auto-merge; Blocky bumps require manual review — see `docs/agents/blocky-bump-review.md` for what that review is.
 
 ## Testing
 

--- a/docs/adr/0009-atomic-version-pin-and-adaptation.md
+++ b/docs/adr/0009-atomic-version-pin-and-adaptation.md
@@ -1,0 +1,13 @@
+# A version bump and its required adaptation land in the same PR
+
+When an upstream Blocky (or Tempio) bump forces a change to our translation layer — a renamed/removed key the template emits, a new enum value we decide to expose, a changed default we must absorb via passive migration — that change rides in the **same PR that moves the version pin**. `main` must never hold a commit where `blocky/Dockerfile` points at a version the template has not been adapted for.
+
+**Why this is not obvious.** The natural instinct is "bump now, adapt in a follow-up PR." That is exactly the state this ADR forbids, and the reason is a consequence of ADR-0003: the render harness reads `BLOCKY_VERSION` *out of the Dockerfile* as its single version pin. So a PR that bumps the pin without the needed adaptation is precisely the state `render-test` is built to fail — and splitting the two across separate PRs would leave `main` red (or, worse, silently mis-rendered) in the window between them. The pin and its adaptation are one atomic change because the harness treats them as one.
+
+**Consequences.**
+
+- A Renovate bump PR that needs no adaptation (the common case — see the bump-review runbook) merges as the bare one-line pin change once `render-test` is green.
+- A bump that *does* need adaptation is not merged as the bare Renovate one-liner. The companion template/schema/golden change is added onto the same PR (push to the Renovate branch, or supersede it with a branch that carries both), so pin and adaptation land together.
+- This forbids the reverse split too: never adapt the template "in advance" for a version the pin has not yet reached — the harness would validate the *old* binary against template output shaped for the *new* one.
+
+**Considered & rejected.** (1) *Decoupling the render pin from the Dockerfile* (a separate version file the harness reads) would let bump and adaptation live in separate PRs, but reintroduces the second source of truth ADR-0003 deliberately removed. (2) *Allowing a follow-up adaptation PR* keeps each PR smaller but accepts a red/mis-rendered `main` in between — unacceptable for a DNS resolver users depend on for connectivity.

--- a/docs/adr/0010-changelog-curated-and-finalized-manually.md
+++ b/docs/adr/0010-changelog-curated-and-finalized-manually.md
@@ -1,0 +1,14 @@
+# The user-facing changelog is curated and finalized manually at release
+
+`blocky/CHANGELOG.md` is a **hand-curated, user-facing** changelog (Keep a Changelog format). semantic-release deliberately never touches it: its `@semantic-release/git` asset list is only `blocky/config.yaml`, there is no `@semantic-release/changelog` plugin, and the machine-generated release notes go to the GitHub release and the release commit message instead. So the changelog's content, its version headings, and the release date are all a human's responsibility.
+
+**Decision.** Entries are written by hand under a **concrete next-version heading** (e.g. `## [5.1.0]`), never a `[Unreleased]` staging heading — because nothing renames `[Unreleased]` to the real version at release, so it would ship stale. The next version number is determined, not guessed: it follows from the conventional commits already merged since the last tag (`feat`/`feat(deps)` → minor, `fix` → patch, `feat!` → major). Before dispatching `release.yml`, someone **assembles and finalizes** the section: aggregate every user-facing change since the last tag under one heading, and set the release date (mirroring `## [5.0.0] - 2026-06-25`).
+
+**Considered & rejected.** `@semantic-release/changelog` would populate the file automatically from the commit-analyzer's release notes — i.e. exactly the raw, per-commit, machine-derived content the curated changelog exists to *avoid*. The value of this file is a small, legible set of user-facing lines (an upgrade, a new option, a behavioral note), not a dump of every `chore(deps)` and `refactor`. Automating it would defeat its purpose. The GitHub release notes already serve the machine-generated audience.
+
+**Consequences.**
+
+- Cutting a release includes a manual changelog-finalize step (assemble the `## [X.Y.Z]` section + date). This step has no automation to fall back on; if skipped, the release ships with a missing or mis-headed changelog.
+- A feature or bump PR *contributes* its lines to the pending section but does not complete it — the section is assembled across PRs and finalized at release-cut time. (`[5.0.0]` "bundles all changes since 4.1.1" is the reference example; intermediate versions were consolidated by hand.)
+- The version heading is a human's call and can drift from semantic-release's computed version if a higher-impact commit (e.g. a `feat!`) lands before the release is cut. The finalize step reconciles the two — the computed version wins, the heading is corrected to match.
+- `blocky-dev/CHANGELOG.md` is a CI-generated mirror (`deploy-dev` rsyncs `blocky/` post-merge); never edit it by hand.

--- a/docs/agents/blocky-bump-review.md
+++ b/docs/agents/blocky-bump-review.md
@@ -1,0 +1,53 @@
+# Reviewing a Blocky version bump
+
+The concrete definition of what CLAUDE.md calls the *manual review* a Blocky bump requires. Renovate opens these as a one-line change to `BLOCKY_VERSION` in `blocky/Dockerfile` (Tempio bumps are the same shape via `TEMPIO_VERSION`). Most bumps merge as that bare one-liner — this runbook is how you earn that conclusion instead of assuming it.
+
+## The two-signal model
+
+A green render harness is **necessary but not sufficient**. It proves our rendered YAML still *parses* against the new binary; it is blind to behavioral changes on keys we emit and to new features we might want to expose. So the review layers two signals with complementary blind spots:
+
+1. **Render harness (schema truth, automated).** The CI `render-test` job reads the new pin out of `blocky/Dockerfile`, downloads that exact binary, and runs `blocky validate` against our goldens (ADR-0003). It fails hard if a key the template emits was renamed or removed. **This is the gate of record** — the merge waits on `render-test` green on the PR, not on a local run.
+2. **Directed changelog scan (semantic truth, human judgement).** Read the upstream release notes, but *directed*: cross each entry against the top-level Blocky keys `blocky.gtpl` actually emits. As of this writing that set is `upstreams`, `bootstrapDns`, `filtering`, `fqdnOnly`, `customDNS`, `conditional`, `ecs`, `dns64`, `rebindingProtection`, `clientLookup`, `blocking`, `caching`, `redis`, `prometheus`, `queryLog`, `ports`, `http3`, `log`, and the TLS/cert fields — but the template is the authoritative source (`grep -nE '^[a-zA-Z].*:' blocky/rootfs/usr/share/tempio/blocky.gtpl`), so re-derive it rather than trusting this list. An entry that touches none of these keys (e.g. an internal dnssec resolution fix) is out of our translation scope and passes without further work. An entry that touches one gets classified below.
+
+## Classifying a changelog entry that touches an emitted key
+
+### Behavioral change (an exposed key behaves differently)
+
+Classify on two axes:
+
+- **Blast radius** — does it change a *default* that affects existing users, or only behavior when an opt-in is *actively enabled*?
+- **Direction** — upstream *bugfix/correction*, or *regression / changed default*?
+
+| | Bugfix / correction | Regression / changed default |
+|---|---|---|
+| **Opt-in / off-by-default** | Note in the PR body, merge. No guard. | Hold: PR-body note + release-note callout; guard/migration if warranted. |
+| **Hits an existing default** | Note + release-note callout. | Hold: active mitigation before merge (passive migration per ADR-0005, or a guard per ADR-0002). |
+
+Do **not** reach for a runtime guard on a mere behavioral shift — ADR-0002 reserves guards for *broken* features (fail-fast / degrade). A guard for "behavior moved" over-extends that semantics.
+
+### New feature (new key or new enum value upstream)
+
+**Default disposition: do not expose.** Standard Mode is curated (ADR-0006) — only options broadly useful in Home Assistant and workable without specialist downstream infrastructure. Exposing is a separate, deliberate feature decision (enum + template branch + translation + fixture/golden + contract check), never a bump side-effect. But the scan must *consciously reject*, not skip: record the non-exposition and its reason, so "deliberately not exposed" is distinguishable from "missed it." Whoever wants the feature uses Custom Config Mode.
+
+Note that a closed enum (e.g. `query_log.type`) makes non-exposition zero-effort — the new value simply isn't in the list, and HA schema validation rejects it. A free-form string field would need an explicit guard against the unhandled value.
+
+## The merge gate
+
+- **Go** when `render-test` is green on the PR **and** the directed scan produced no un-mitigated Hold. A bump needing no adaptation merges as the bare one-liner.
+- **Hold** when the scan surfaces an un-absorbed behavioral change (see table), or `render-test` is red.
+- A red `render-test` means a key we emit broke upstream. The fix is a companion template/schema/golden change — and it rides in the **same PR** as the pin bump, never a follow-up (ADR-0009). `blocky-dev/` is CI-generated post-merge; it is not part of the bump PR.
+
+## Changelog and release
+
+A bump touches the user-facing changelog, but does not complete it. `blocky/CHANGELOG.md` is hand-curated and finalized manually at release (ADR-0010) — semantic-release stamps only `blocky/config.yaml`'s `version:`, never the changelog.
+
+- Add the bump's lines under the **concrete next-version heading** (e.g. `## [5.1.0]`), never `[Unreleased]` — nothing renames it at release. The next version follows from the conventional commits already merged since the last tag (`feat(deps):` is a minor).
+- The upgrade line goes under `### Changed` ("Blocky upgraded from vX to vY"), and any behavioral note the classification produced (e.g. the ecs ordering note) rides with it — the changelog is the durable user-facing home for that note, not a PR comment.
+- Assembling the full section (every user-facing change since the last tag) and setting the release date is a manual step at release-cut time, not part of the bump PR.
+
+## Worked example — Blocky 0.33.0 (PR #266)
+
+- **dnssec: Indeterminate not Bogus** — internal resolution behavior; we emit no `dnssec`. Out of scope, passes.
+- **ecs `useAsClient` applied above cache/client-name lookup** — touches `ecs.useAsClient`, which we emit. Off by default (`use_as_client: false`), opt-in, and an upstream *bugfix*. → top-left cell: note in PR body, merge, no guard.
+- **`dnstap` as a new `queryLog.type`** — touches `queryLog`, which we curate. New feature, and `query_log.type` is a closed enum that already excludes it. → default disposition: not exposed, recorded here as the deliberate rejection. Belongs in Custom Config Mode.
+- `render-test` green against the 0.33.0 binary → no schema break. **Merge decision: go, bare one-liner.**


### PR DESCRIPTION
Documents the manual review a Blocky version bump requires. CLAUDE.md previously said only "Blocky bumps require manual review" without defining it — this fills that gap and captures the two decisions the review rests on.

## Contents

- **`docs/agents/blocky-bump-review.md`** — the bump-review runbook:
  - Two-signal model: the render harness (`blocky validate` against goldens) is the hard schema gate; a *directed* changelog scan against the keys `blocky.gtpl` emits catches behavioral/additive changes `validate` can't see.
  - A behavioral-change classification matrix (blast radius × direction).
  - Default "do not expose new upstream features" disposition, with documented rejection (ADR-0006).
  - The merge gate and the manual changelog/release step.
  - Worked example: Blocky 0.33.0.
- **`docs/adr/0009-atomic-version-pin-and-adaptation.md`** — a version pin and its required template adaptation land in the same PR (never a window where `main`'s pin is ahead of the template).
- **`docs/adr/0010-changelog-curated-and-finalized-manually.md`** — the user-facing changelog is hand-curated and finalized at release; semantic-release never touches it (deliberately rejects `@semantic-release/changelog`).
- **`CLAUDE.md`** — points the Renovate line at the runbook.

Docs only — `docs:` commit, no release trigger.