### PR TITLE
feat(deps): update Blocky to v0.33.0

### DIFF
--- a/blocky/CHANGELOG.md
+++ b/blocky/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [5.1.0] - unreleased
+
+### Added
+
+- Outgoing connection IP version control: `connect_ip_version` (`dual`/`v4`/`v6`) restricts whether Blocky uses IPv4, IPv6, or both when connecting to upstream resolvers (#256)
+
+### Changed
+
+- Blocky upgraded from v0.32.1 to v0.33.0
+- ECS `use_as_client` now applies before caching and client-name lookup (upstream fix in Blocky 0.33.0). No configuration change is needed; this only affects setups that have `ecs.use_as_client: true`.
+
 ## [5.0.0] - 2026-06-25
 
 Bundles all changes since 4.1.1 (the previously documented 4.2.0 was never released; its contents ship here).

--- a/blocky/Dockerfile
+++ b/blocky/Dockerfile
@@ -11,7 +11,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Setup base
 ARG BUILD_ARCH
 # renovate: datasource=github-releases depName=0xERR0R/blocky
-ARG BLOCKY_VERSION=v0.32.1
+ARG BLOCKY_VERSION=v0.33.0
 # renovate: datasource=github-releases depName=home-assistant/tempio
 ARG TEMPIO_VERSION=2024.11.2
 # IMPORTANT: Tempio does not publish checksums; update all hashes when


### PR DESCRIPTION
Supersedes #266 (the Renovate bump), carrying the same `BLOCKY_VERSION` change **plus its curated changelog entry atomically** (ADR-0009).

## Changes

- `blocky/Dockerfile`: `BLOCKY_VERSION` v0.32.1 → v0.33.0
- `blocky/CHANGELOG.md`: new `[5.1.0]` section

## Bump review

Per `docs/agents/blocky-bump-review.md`:

- **render-test**: green against the 0.33.0 binary — no key the template emits was renamed or removed.
- **ecs**: `useAsClient` now applies above cache/client-name lookup (upstream fix in 0.33.0). Off by default, opt-in only → changelog note, no code change.
- **dnstap** as a new `queryLog.type`: **not exposed**. `query_log.type` is a closed enum and dnstap is a specialist streaming sink (ADR-0006) → belongs in Custom Config Mode.
- Also backfills the pending `[5.1.0]` changelog with `connect_ip_version` (#256), which had no entry yet.

`[5.1.0]` is marked `unreleased`; its date is set at release-cut time (ADR-0010), and semantic-release stamps the version into `config.yaml`.