### PR TITLE
docs: set 5.1.0 changelog release date

### DIFF
--- a/blocky/CHANGELOG.md
+++ b/blocky/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [5.1.0] - unreleased
+## [5.1.0] - 2026-07-04
 
 ### Added
 


### PR DESCRIPTION
Dates the pending `## [5.1.0]` changelog heading (`unreleased` → `2026-07-04`) ahead of cutting the 5.1.0 release.

Per ADR-0010, `blocky/CHANGELOG.md` is hand-curated and dated manually at release time — semantic-release never touches it. The version **5.1.0** is confirmed via `semantic-release --dry-run` (two `feat` commits since v5.0.0: #256 and #270 → minor).

`docs:` — no release impact. Merge this, then dispatch `release.yml`.