### PR TITLE
fix: align conventional-changelog-conventionalcommits to writer-compatible v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "12.0.8",
     "@semantic-release/release-notes-generator": "14.1.1",
-    "conventional-changelog-conventionalcommits": "^10.0.0",
+    "conventional-changelog-conventionalcommits": "^9.0.0",
     "semantic-release": "25.0.5",
     "yaml": "^2.9.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: 14.1.1
         version: 14.1.1(semantic-release@25.0.5)
       conventional-changelog-conventionalcommits:
-        specifier: ^10.0.0
-        version: 10.2.0
+        specifier: ^9.0.0
+        version: 9.3.1
       semantic-release:
         specifier: 25.0.5
         version: 25.0.5
@@ -66,10 +66,6 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
-
-  '@conventional-changelog/template@1.2.0':
-    resolution: {integrity: sha512-12qHxvlKjHmP0PQ+17EREgC7lWyLwbph1RKcZQZ7k7ZWGmrxfxC9gadHGfvzr0g0u8BhiBGg3tks93txodlyRQ==}
-    engines: {node: '>=22'}
 
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
@@ -320,9 +316,9 @@ packages:
     resolution: {integrity: sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==}
     engines: {node: '>=18'}
 
-  conventional-changelog-conventionalcommits@10.2.0:
-    resolution: {integrity: sha512-UtlM9GqolY7OmlQh5L/UEVoKsTUpTgUVy1PU8JN5gl5Ydaejb7WRklGliG1SKPxxj7hzA173eG3Kt5fYWE2pmg==}
-    engines: {node: '>=22'}
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
+    engines: {node: '>=18'}
 
   conventional-changelog-writer@8.2.0:
     resolution: {integrity: sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw==}
@@ -1318,8 +1314,6 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@conventional-changelog/template@1.2.0': {}
-
   '@octokit/auth-token@6.0.0': {}
 
   '@octokit/core@7.0.6':
@@ -1630,9 +1624,9 @@ snapshots:
     dependencies:
       compare-func: 2.0.0
 
-  conventional-changelog-conventionalcommits@10.2.0:
+  conventional-changelog-conventionalcommits@9.3.1:
     dependencies:
-      '@conventional-changelog/template': 1.2.0
+      compare-func: 2.0.0
 
   conventional-changelog-writer@8.2.0:
     dependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -62,12 +62,14 @@
       "automerge": false
     },
     {
-      "description": "Group semantic-release packages",
+      "description": "Group release tooling (semantic-release plugins and the conventionalcommits changelog preset) and keep it manual. These drive the release pipeline; a preset major that outpaces the plugins silently empties the GitHub release notes, so every bump must be reviewed against `pnpm release:dry-run`.",
       "groupName": "semantic-release packages",
       "matchPackageNames": [
         "/^@semantic-release//",
-        "/^semantic-release$/"
-      ]
+        "/^semantic-release$/",
+        "conventional-changelog-conventionalcommits"
+      ],
+      "automerge": false
     },
     {
       "description": "Blocky updates trigger a version bump and require manual review",


### PR DESCRIPTION
## Problem

The **v5.1.0 GitHub release notes came out empty** — just the compare-link header, no `Features` section — even though the release contained two `feat` commits (#256, #270).

## Root cause

#265 bumped `conventional-changelog-conventionalcommits` to **v10**. That preset generation targets `conventional-changelog-writer@9`, but `@semantic-release/release-notes-generator@14.1.1` (the **latest**) still bundles `conventional-changelog-writer@^8` (and `conventional-changelog-angular@^8`). The matching conventionalcommits generation for writer 8 is **v9**.

With v10's `writerOpts` fed to writer 8, the template renders empty sections — while `@semantic-release/commit-analyzer` still *parses* the commits (so it computed `minor`, but produced no notes). That's why the version was right but the body was blank.

## Why pin rather than upgrade or remove

- `commit-analyzer@13.0.1` and `release-notes-generator@14.1.1` are **already `@latest`** — there is no newer plugin that adopts writer 9 / preset v10.
- The preset **can't be dropped**: the plugins bundle only the *angular* preset, so `preset: "conventionalcommits"` requires this direct dependency.

So `^9` is the generation the current tooling actually runs on, not an outdated fallback. When semantic-release moves to writer 9, the preset gets bumped to v10 **in lockstep**, reviewed via `pnpm release:dry-run`.

## Changes

- `package.json`: `conventional-changelog-conventionalcommits` `^10.0.0` → `^9.0.0` (resolves 9.3.1)
- `pnpm-lock.yaml`: updated
- `renovate.json`: the preset now sits in the manual **"semantic-release packages"** group (`automerge: false`), so a future preset major is reviewed against the release pipeline instead of landing silently (as v10 did)

## Proof

Calling the exact `generateNotes` semantic-release uses, with v9 installed, against the real `v5.0.0..v5.1.0` commits that produced the empty notes:

```
## [5.1.0](.../compare/v5.0.0...v5.1.0) (2026-07-04)

### Features
* add connect ip version option (#256) (5f6e79d)
* **deps:** update Blocky to v0.33.0 (#270) (c91701b)
```

Populated again. (The v5.1.0 release body has already been backfilled manually.)

Note: committed as `fix:`, so it contributes a "Bug Fixes" line to the next release.