### PR TITLE
docs(changelog): finalize the 5.2.0 section for release

### DIFF
--- a/blocky/CHANGELOG.md
+++ b/blocky/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [5.2.0]
+## [5.2.0] - 2026-07-31
 
 ### Changed
 


### PR DESCRIPTION
Release-cut step per [ADR-0010](https://github.com/robocopklaus/hassio-addon-blocky/blob/main/docs/adr/0010-changelog-curated-and-finalized-manually.md): sets the release date on the `## [5.2.0]` heading.

The section is content-complete as-is. Only `336e7a5` (Blocky v0.33.0 → v0.34.0, #287) touched `blocky/` since `v5.1.0`; every other commit in that range is repo tooling (pnpm, semantic-release, `actions/setup-node`, the js-yaml dev override) and therefore not user-facing.

Version heading reconciles with semantic-release's computed version: `feat(deps):` is the only release-triggering commit since v5.1.0 → minor → 5.2.0.