### PR TITLE
docs: document wayfinding operations for the GitHub issue tracker

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -32,3 +32,14 @@ Create a GitHub issue.
 ## When a skill says "fetch the relevant ticket"
 
 Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.


### PR DESCRIPTION
## What

Appends the `## Wayfinding operations` section to `docs/agents/issue-tracker.md`, bringing it back in line with the current `setup-matt-pocock-skills` GitHub seed template.

## Why

The repo's copy of this doc predated the section, so `/wayfinder` found no tracker-specific guidance and derived the GitHub mechanics by hand. That worked — the derived approach matched the template independently — but it is re-derived every session and the riskier details are easy to get wrong:

- sub-issue and dependency endpoints take the issue's numeric **database id**, not its `#number` or `node_id` (`-F`, not `-f` — `-f` fails with a 422)
- the frontier query gates on `issue_dependencies_summary.blocked_by`, which counts **open** blockers only
- claiming a ticket by assigning it must be the session's first write, or parallel sessions collide

The section also documents fallbacks for repos where sub-issues or native dependencies aren't enabled.

## Scope

Purely additive: 11 lines appended, nothing else in the file touched. `docs/agents/domain.md` and `docs/agents/triage-labels.md` were already byte-identical to their seeds and are unchanged, as is the `## Agent skills` block in `CLAUDE.md`.

Docs only — no code, config, or template changes, so nothing here affects the rendered Blocky config.