### PR TITLE
fix: move outgoing IP version to the top of the options list

### DIFF
--- a/blocky/config.yaml
+++ b/blocky/config.yaml
@@ -26,6 +26,7 @@ map:
   - addon_config:rw
   - ssl:ro
 options:
+  connect_ip_version: dual
   upstreams:
     groups:
       - name: default
@@ -40,7 +41,6 @@ options:
     quic:
       max_idle_timeout: ""
       keep_alive_period: ""
-  connect_ip_version: dual
   bootstrap:
     dns:
       - upstream: 1.1.1.1
@@ -138,6 +138,7 @@ options:
     privacy: true
   custom_config: false
 schema:
+  connect_ip_version: list(dual|v4|v6)?
   upstreams:
     groups:
       - name: str
@@ -151,7 +152,6 @@ schema:
     quic:
       max_idle_timeout: str?
       keep_alive_period: str?
-  connect_ip_version: list(dual|v4|v6)?
   bootstrap:
     dns:
       - upstream: str

--- a/blocky/translations/en.yaml
+++ b/blocky/translations/en.yaml
@@ -1,5 +1,10 @@
 ---
 configuration:
+  connect_ip_version:
+    name: Outgoing IP Version
+    description: >-
+      Controls which IP protocol Blocky uses for outgoing network connections, including upstream DNS resolvers and downloaded blocklists. Use dual for normal dual-stack behavior, v4 to force IPv4, or v6 to force IPv6. This does not filter client DNS query types or suppress AAAA answers; use Filtering if you need to block specific DNS record types. Default: dual.
+
   upstreams:
     name: Upstream DNS Servers
     description: >-
@@ -43,11 +48,6 @@ configuration:
         description: >-
           Custom User-Agent header for DNS-over-HTTPS (DoH) requests. Only applies to HTTPS upstream resolvers (https://...). Some DNS providers require or prefer specific User-Agent strings for identification, rate limiting, or analytics purposes. Leave empty to use Blocky's default User-Agent. Has no effect on DNS-over-TLS (tcp-tls:...), DNS-over-QUIC (quic:...), or plain DNS resolvers. Example: "MyNetwork-DNS/1.0" or "Blocky-HomeAssistant".
 
-  connect_ip_version:
-    name: Outgoing IP Version
-    description: >-
-      Controls which IP protocol Blocky uses for outgoing network connections, including upstream DNS resolvers and downloaded blocklists. Use dual for normal dual-stack behavior, v4 to force IPv4, or v6 to force IPv6. This does not filter client DNS query types or suppress AAAA answers; use Filtering if you need to block specific DNS record types. Default: dual.
-  
   bootstrap:
     name: Bootstrap DNS
     description: >-


### PR DESCRIPTION
## Problem

`connect_ip_version` ("Outgoing IP Version") is one of only two scalar top-level options — everything else is an object that the Home Assistant UI renders as a group with a heading. It therefore appeared as a headingless field wedged between the **Upstream DNS Servers** and **Bootstrap DNS** groups, visually belonging to neither.

## Change

Moved it ahead of `upstreams` in `options:`, `schema:` and `translations/en.yaml`. The HA UI renders in schema order, so it now sits at the top of the form and reads as a global network default.

## Cost

None — the key, its default and the template are unchanged. Ordering in `config.yaml` does not affect the rendered Blocky YAML (that order comes from `blocky.gtpl`), so there is no deprecation (ADR-0005 does not apply) and no golden updates.

## Verification

`pnpm check` → contracts ✓, guards ✓. Render did not run locally (Docker unavailable; the harness is Linux-only) — CI covers it.