### PR TITLE
fix: mark seven optional list options as optional in the schema

### DIFF
--- a/blocky/DOCS.md
+++ b/blocky/DOCS.md
@@ -34,7 +34,7 @@ See [Custom Config Mode](#custom-config-mode) for how to enable and use it.
 
 **"Required" means the key must be present — not that you must fill it in.** An empty string, an empty list, or a zero all satisfy Home Assistant's check, so a required field you have never touched is not doing anything. What is genuinely enforced is the required keys *inside* a list entry — a denylist's `name`, a bootstrap DNS `upstream`, a Custom DNS `hostname` — because those are map keys in Blocky's own YAML. At the top level, nothing must be set.
 
-**Deleting settings you don't use won't shrink your configuration.** Home Assistant merges this add-on's defaults back underneath your saved options every time it reads them, so a deleted key reappears — and for whole groups and lists it is refused outright with `Missing option '<key>' in <group>`, because Home Assistant's schema language has no way to mark a group optional. Leave the defaults alone. If the size of the configuration is what bothers you, that is what Custom Config Mode is for.
+**Deleting settings you don't use won't shrink your configuration.** Home Assistant merges this add-on's defaults back underneath your saved options every time it reads them, so a deleted key reappears — and for whole groups and lists of entries it is refused outright with `Missing option '<key>' in <group>`, because Home Assistant's schema language has no way to mark a group optional. Leave the defaults alone. If the size of the configuration is what bothers you, that is what Custom Config Mode is for.
 
 ### Finding a Blocky option in the add-on
 
@@ -481,7 +481,7 @@ DNS amplification is a type of DDoS attack where an attacker sends small DNS que
 
 ### Saving options fails with a missing-option error
 
-Home Assistant refuses to save with `Missing option '<key>' in <group>` if you delete a whole settings group or list from the add-on's YAML editor. Its schema language has no way to mark a group as optional, so every group this add-on defines must be present. Put the key back — nothing is broken.
+Home Assistant refuses to save with `Missing option '<key>' in <group>` if you delete a whole settings group, or a list of entries such as an upstream group, a denylist, or a client mapping, from the add-on's YAML editor. Its schema language has no way to mark those as optional, so every one this add-on defines must be present. Put the key back — nothing is broken. Lists of plain values, such as `query_types` or `exclude`, can be deleted without the error, though they too reappear on the next page load.
 
 Deleting settings you don't use won't shrink your configuration in any case: Home Assistant merges the add-on's defaults back underneath your saved options every time it reads them. See [What's actually required](#whats-actually-required) for why, and [Custom Config Mode](#custom-config-mode) if a smaller configuration file is what you're after.
 

--- a/blocky/config.yaml
+++ b/blocky/config.yaml
@@ -159,7 +159,7 @@ schema:
           - str?
   filtering:
     query_types:
-      - str
+      - str?
   fqdn_only:
     enable: bool?
   custom_dns:
@@ -186,17 +186,17 @@ schema:
   dns64:
     enable: bool?
     prefixes:
-      - str
+      - str?
     exclusion_set:
-      - str
+      - str?
   rebinding_protection:
     enable: bool?
     allowed_domains:
-      - str
+      - str?
   client_lookup:
     upstream: str?
     single_name_order:
-      - match(^[1-9][0-9]*$)
+      - match(^[1-9][0-9]*$)?
     clients:
       - name: str
         addresses:
@@ -237,7 +237,7 @@ schema:
     prefetch_max_items_count: int(0,)?
     cache_time_negative: str?
     exclude:
-      - str
+      - str?
   redis:
     address: str?
     username: str?
@@ -267,7 +267,7 @@ schema:
     creation_attempts: int(1,)?
     creation_cooldown: str?
     fields:
-      - list(clientIP|clientName|responseReason|responseAnswer|question|duration)
+      - list(clientIP|clientName|responseReason|responseAnswer|question|duration)?
     flush_interval: str?
   log:
     level: list(trace|debug|info|warn|error)?


### PR DESCRIPTION
Closes #302.

Seven list-typed options in `blocky/config.yaml`'s `schema:` block were marked required when Blocky treats them as optional. Home Assistant's requiredness check defers a list to its **element** type, so the fix is a single `?` on the element:

| Key | Was | Now |
|---|---|---|
| `filtering.query_types` | `[str]` | `[str?]` |
| `dns64.prefixes` | `[str]` | `[str?]` |
| `dns64.exclusion_set` | `[str]` | `[str?]` |
| `rebinding_protection.allowed_domains` | `[str]` | `[str?]` |
| `caching.exclude` | `[str]` | `[str?]` |
| `client_lookup.single_name_order` | `[match(…)]` | `[match(…)?]` |
| `query_log.fields` | `[list(…)]` | `[list(…)?]` |

Each defaults to `[]`, each is meaningless when empty, and none is required by Blocky. Deleting one in the YAML editor was rejected with `Missing option '<key>' in <group>`.

## Non-breaking

The `?` is read only by `_check_missing_options` (key presence) and `_single_ui_option` (the UI's optional/required flag). `_nested_validate_list` still routes every element through `_single_validate`, which rejects `None`, so element validation is unchanged. Nothing is removed from the schema, so ADR-0005 is not in play.

## Docs

`blocky/DOCS.md` asserted in two places that deleting a whole group *or list* is refused outright. After this change that holds only for lists of **entries** (upstream groups, denylists, client mappings), so both passages are narrowed and the plain-value case is stated explicitly.

This replaces a misleading hard error with a silent no-op. It is not operator-facing relief — `App.options` still re-merges defaults on every read, so a deleted key reappears on the next page load.

## Verification

`pnpm check` green end to end — contracts, guards, and render (17/17 fixtures, via Docker on macOS). No golden movement; the only non-doc change is 7 characters in the schema block.