### PR TITLE
docs(changelog): record the #299 and #308 fixes under 5.2.1

### DIFF
--- a/blocky/CHANGELOG.md
+++ b/blocky/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [5.2.1]
+
+### Fixed
+
+- **Outgoing IP Version** now appears at the top of the add-on configuration form instead of sitting unlabelled between the **Upstream DNS Servers** and **Bootstrap DNS** groups, where it read as part of neither (#299)
+- Seven optional list options are no longer marked required in the configuration schema, so clearing them in the YAML editor is no longer refused with `Missing option '<key>' in <group>`: `filtering.query_types`, `dns64.prefixes`, `dns64.exclusion_set`, `rebinding_protection.allowed_domains`, `caching.exclude`, `client_lookup.single_name_order` and `query_log.fields`. Home Assistant still re-merges the defaults on the next page load, so a cleared key reappears there (#308)
+
 ## [5.2.0] - 2026-07-31
 
 ### Changed


### PR DESCRIPTION
## Problem

Two user-facing `fix:` commits have landed since `v5.2.0` with no entry in the curated changelog:

- #299 — moved **Outgoing IP Version** to the top of the options list
- #308 — marked seven optional list options as optional in the schema

Everything else since the tag is `docs:` or `chore:`, which the curated changelog deliberately omits.

## Change

Adds a `## [5.2.1]` section with a `### Fixed` entry for each.

## Version heading

Per ADR-0010 the heading is concrete and undated: `## [5.2.1]`, never `[Unreleased]`, with the date set at release-cut. 5.2.1 follows from `fix:` → patch with no `feat:`/`feat!:` since the tag. `semantic-release --dry-run` is branch-gated to `main`, so it could not confirm this locally; ADR-0010's finalize step reconciles the heading if the computed version drifts.

## Verification

`pnpm check:contracts` green. No schema, template or golden changes — the diff is `blocky/CHANGELOG.md` only.