### PR TITLE
docs(changelog): finalize the 5.2.1 section for release

### DIFF
--- a/blocky/CHANGELOG.md
+++ b/blocky/CHANGELOG.md
@@ -284,7 +284,7 @@ Additional breaking changes:
 - Container image path: `ghcr.io/robocopklaus/hassio-addon-blocky-{arch}` → `ghcr.io/robocopklaus/hassio-addon-blocky/{arch}`
 - i386 architecture no longer supported
 
-## [0.3.0] and earlier
+## 0.3.0 and earlier
 
 See [git history](https://github.com/robocopklaus/hassio-addon-blocky/commits) for previous releases.
 
@@ -299,5 +299,4 @@ See [git history](https://github.com/robocopklaus/hassio-addon-blocky/commits) f
 [3.1.0]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v2.0.0...v3.0.0
 [2.0.0]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v1.0.0...v2.0.0
-[1.0.0]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v0.3.0...v1.0.0
-[0.3.0]: https://github.com/robocopklaus/hassio-addon-blocky/releases/tag/v0.3.0
+[1.0.0]: https://github.com/robocopklaus/hassio-addon-blocky/releases/tag/v1.0.0

--- a/blocky/CHANGELOG.md
+++ b/blocky/CHANGELOG.md
@@ -288,7 +288,10 @@ Additional breaking changes:
 
 See [git history](https://github.com/robocopklaus/hassio-addon-blocky/commits) for previous releases.
 
-[4.2.0]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v4.1.1...v4.2.0
+[5.2.1]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v5.2.0...v5.2.1
+[5.2.0]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v5.1.0...v5.2.0
+[5.1.0]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v5.0.0...v5.1.0
+[5.0.0]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v4.1.1...v5.0.0
 [4.1.1]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v4.1.0...v4.1.1
 [4.1.0]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/robocopklaus/hassio-addon-blocky/compare/v3.2.0...v4.0.0

--- a/blocky/CHANGELOG.md
+++ b/blocky/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [5.2.1]
+## [5.2.1] - 2026-08-02
+
+### Added
+
+- A **How configuration works** section at the top of the add-on documentation: how the options form maps onto Blocky's YAML, Standard Mode vs. Custom Config Mode, which options are genuinely required, and how to find a given Blocky option in the add-on (#304)
 
 ### Fixed
 


### PR DESCRIPTION
Finalizes the pending `[5.2.1]` section so `release.yml` can be dispatched — the manual release-cut step ADR-0010 mandates — and repairs the compare-link block at the foot of the file.

## Release-cut changes

- **Date set**: `## [5.2.1]` → `## [5.2.1] - 2026-08-02`. Per ADR-0010 the curated changelog is dated by hand at release-cut time; nothing automates this, so an undated heading would ship as-is.
- **`### Added` for #304**: the `How configuration works` section added to `blocky/DOCS.md` is user-facing documentation rendered in the Home Assistant UI, and there is precedent for such lines (`Comprehensive documentation improvements (README, DOCS, translations)` under *Added* in 5.0.0). Without it the section read as fixes-only.

The two `### Fixed` entries (#299, #308) are untouched.

## Link-block repair

- **Missing compare links**: the definitions stopped at `[4.2.0]`, so every heading from `[5.0.0]` onward rendered as literal bracketed text rather than a link. Adds `[5.0.0]`, `[5.1.0]`, `[5.2.0]`, `[5.2.1]`.
- **Dangling `[4.2.0]`**: 4.2.0 was never released and its contents were consolidated into 5.0.0 (e5eef1c), which removed the `## [4.2.0]` heading. The definition was left behind with no referrer, pointing at a `v4.2.0` tag that does not exist. Removed. For the same reason `[5.0.0]` compares against `v4.1.1`.
- **Dead `v0.3.0` references**: no `v0.3.0` tag or GitHub release exists — `v1.0.0` is the first tag in the repo — so both references 404. `[1.0.0]` now points at the `v1.0.0` release tag (no earlier tag to compare against), and `[0.3.0]` is removed with its heading de-linked to `## 0.3.0 and earlier`. That section's body already links the git history, the only real source for that era.

## Deliberately unchanged: 3.2.1 / 3.2.2

Tags `v3.2.1` and `v3.2.2` have no changelog headings. That is correct, not a gap: both releases contain a single `fix(ci):` commit each (#163, #164 — smoke-test repairs) with nothing user-facing, and ADR-0010 scopes this file to user-facing lines. `[4.0.0]` compares against `v3.2.0`, so its range still spans those commits — nothing is unreachable.

## Verification

- Version headings and link definitions correspond exactly in both directions — no heading without a definition, no definition without a heading.
- Every add-on tag referenced from a link definition exists, except `v5.2.1`, which the release run creates.
- `git diff v5.2.0..main -- blocky/` — the only changed files are `config.yaml` + `translations/en.yaml` (#299, #308), `DOCS.md` (#304) and `CHANGELOG.md` itself. No user-facing change since the tag is missing from the section.
- `version: 5.2.0` in `blocky/config.yaml` is intentionally left alone — `scripts/update-addon-version.mjs` stamps it during the release run.
- `pnpm check` green end to end — contracts ✓, guards ✓, render ✓ (17/17 fixtures, via Docker on macOS). The diff is `blocky/CHANGELOG.md` only.