### PR TITLE
fix(docker): use exec form for HEALTHCHECK CMD

### DIFF
--- a/blocky/Dockerfile
+++ b/blocky/Dockerfile
@@ -98,4 +98,4 @@ LABEL \
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD blocky blocking status || exit 1
+    CMD ["blocky", "blocking", "status"]


### PR DESCRIPTION
hadolint 2.15.0 extended **DL3025** to `HEALTHCHECK` instructions ([hadolint/hadolint#1209](https://github.com/hadolint/hadolint/pull/1209)), so the shell-form healthcheck now fails the Hadolint job. This surfaced in #331, which bumps `hadolint-action` v3.3.0 → v3.4.0 and with it the bundled linter v2.14.0 → v2.15.0.

```diff
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD blocky blocking status || exit 1
+    CMD ["blocky", "blocking", "status"]
```

The `|| exit 1` was redundant: `blocky blocking status` already exits nonzero on failure and Docker treats any nonzero exit as unhealthy, so the exec form is behaviourally identical. Chose this over ignoring DL3025 in `.hadolint.yaml` because the shell wrapper bought nothing here.

## Verification

Differential run of the pinned linter versions against the Dockerfile:

```
for v in v2.14.0 v2.15.0; do docker run --rm -i \
  -v "$PWD/.hadolint.yaml:/.config/hadolint.yaml:ro" \
  ghcr.io/hadolint/hadolint:$v hadolint - < blocky/Dockerfile; done
```

- Before: v2.14.0 clean, v2.15.0 `-:100 DL3025` (exactly the CI annotation)
- After: both exit 0

Against a real `docker build`:

- Image metadata is `{"Test":["CMD","blocky","blocking","status"],...}` — exec form, no shell
- `blocky` resolves on PATH without a shell and exits `1` with the API-refused error when Blocky is not up

`pnpm check` passes (contracts + guards + all 17 render fixtures).

Once this is on `main`, #331 needs a rebase to pick it up and go green.